### PR TITLE
fix: use proper IMDb acronym in comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@ function providerSlug(name){
   return '';
 }
 
-// pull external IDs → imdb → OMDb ratings
+// pull external IDs → IMDb → OMDb ratings
 async function enrichWithRatings(items){
   const out = [];
   // cap to 12 items per batch for speed


### PR DESCRIPTION
## Summary
- Correct reference to IMDb in ratings retrieval comment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1e9143d4832d9296b3fca744d62b