### PR TITLE
Fix dropped results during rating enrichment

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,9 +311,12 @@ async function enrichWithRatings(items){
         }
       }
       out.push({...it, imdb_id: imdb || null, imdbRating, rtRating});
-    }catch(e){ out.push(it); }
+    }catch(e){
+      out.push(it);
+    }
   }
-  return out;
+  // return enriched items followed by any remaining originals
+  return out.concat(items.slice(12));
 }
 
 function card(t){


### PR DESCRIPTION
## Summary
- ensure `enrichWithRatings` returns non-enriched items instead of discarding them

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1cfae194832d9a13f847350919e8