### PR TITLE
Clarify mood nudge comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@ function buildDiscoverURL(page=1){
     add("vote_count.gte","100");
   }
 
-  // Mood nudges via keywords/genres where possible
+  // Mood nudges via genres where possible
   const mood = $("#mood").value;
   const moodGenres = {
     feelgood: ["35","10751"],      // Comedy, Family


### PR DESCRIPTION
## Summary
- Clarify mood nudge comment to mention only genre-based suggestions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1e8c7010832da21e32f03dbc7335