### PR TITLE
Inline providerSlug to fix UI init

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,11 +137,30 @@
   </div>
 </main>
 
-<script type="module">
-import { providerSlug } from './src/providerSlug.js';
+<script>
 /*** 🔧 CONFIG — add your keys ***/
 const TMDB_KEY = "f653b3ff00c4561dfaebe995836a28e7";
 const OMDB_KEY = "84da1316"; // free 1k/day; upgrade if needed
+
+function providerSlug(name) {
+  const n = name.toLowerCase();
+  if (n.includes('freevee')) return 'freevee';
+  if (n.includes('prime') || n.includes('amazon')) return 'prime';
+  if (n.includes('netflix')) return 'netflix';
+  if (n.includes('disney')) return 'disney';
+  if (n.includes('hulu')) return 'hulu';
+  if (n === 'max' || n.includes('hbo')) return 'max';
+  if (n.includes('apple')) return 'appletv';
+  if (n.includes('paramount')) return 'paramount';
+  if (n.includes('peacock')) return 'peacock';
+  if (n.includes('starz')) return 'starz';
+  if (n.includes('showtime')) return 'showtime';
+  if (n.includes('amc')) return 'amc';
+  if (n.includes('criterion')) return 'criterion';
+  if (n.includes('tubi')) return 'tubi';
+  if (n.includes('pluto')) return 'pluto';
+  return '';
+}
 
 const state = {
   type: "movie",


### PR DESCRIPTION
## Summary
- Inline providerSlug helper in index.html to avoid module import failure that prevented genres and provider data from loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c27c48978832da965de174be22cf6