### PR TITLE
refactor: extract stylesheet and add responsive queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,57 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Bungee&display=swap" rel="stylesheet">
-<style>
-  :root { --radius:14px; --pad:14px; --bg:#0f1115; --card:#171a21; --ink:#e8ecf1; --muted:#a9b4c0; --accent:#7cf; }
-  *{box-sizing:border-box;font-family:ui-sans-serif,system-ui,Segoe UI,Apple Color Emoji,Arial}
-  body{margin:0;background:linear-gradient(180deg,#0c0f13,#10131a 40%,#0f1115);color:var(--ink)}
-  header{padding:22px var(--pad); position:sticky; top:0; backdrop-filter: blur(10px); background:#0f1115cc; border-bottom:1px solid #222}
-  h1{margin:0;font-size:28px;letter-spacing:0.5px;font-family:'Bungee', system-ui;line-height:1}
-  .brand{display:flex;gap:10px;align-items:center}
-  .brand .title-text{background:linear-gradient(90deg,#7cf,#48c,#8ef); background-clip:text; -webkit-background-clip:text; color:transparent; text-shadow:0 2px 16px rgba(124,255,255,0.15)}
-  main{padding:18px;max-width:940px;margin:0 auto}
-  .panel{background:var(--card); border:1px solid #222; border-radius:var(--radius); padding:var(--pad); margin-bottom:16px}
-  .row{display:flex;gap:10px;flex-wrap:wrap}
-  .chip{padding:8px 12px; border:1px solid #2a2f39; border-radius:999px; cursor:pointer; user-select:none}
-  .chip input{display:none}
-  .chip.active{border-color:var(--accent); box-shadow:0 0 0 2px #7cf3 inset}
-  label{display:block;margin:8px 0 4px;font-weight:600;color:#dbe3ec}
-  select, input[type="range"], input[type="text"]{
-    width:100%; background:#0f1218; color:var(--ink); border:1px solid #2a2f39; border-radius:10px; padding:10px
-  }
-  button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer}
-  .btn{background:linear-gradient(135deg,#48c,#7cf); color:#02111f}
-  .btn.secondary{background:#1e2430;color:#cfe7ff;border:1px solid #2a323e}
-  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr)); gap:14px}
-  .card{background:#0d1118;border:1px solid #202532;border-radius:16px;overflow:hidden;display:flex;flex-direction:column}
-  .poster{aspect-ratio:2/3;background:#0a0d12;object-fit:cover;width:100%}
-  .meta{padding:12px}
-  .title{font-weight:800;line-height:1.2;margin:0 0 6px}
-  .badges{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0}
-  .badge{font-size:12px;padding:6px 8px;border:1px solid #2a2f39;border-radius:999px;color:#cfe3ff}
-  .provline{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0}
-  .prov-badge{font-size:12px;padding:6px 10px;border-radius:999px;font-weight:800;border:1px solid transparent}
-  /* Brand color badges */
-  .prov-badge.netflix{background:#E50914; color:#fff}
-  .prov-badge.prime,.prov-badge.amazon{background:#00A8E1; color:#001}
-  .prov-badge.freevee{background:#A5E000; color:#081}
-  .prov-badge.disney{background:#113CCF; color:#fff}
-  .prov-badge.hulu{background:#1CE783; color:#021}
-  .prov-badge.max{background:#5B61F6; color:#fff}
-  .prov-badge.appletv{background:#a3aaae; color:#111}
-  .prov-badge.paramount{background:#0064FF; color:#fff}
-  .prov-badge.peacock{background:#1f1f1f; color:#fff; border-color:#444}
-  .prov-badge.starz{background:#0b0d10; color:#d4f7ff}
-  .prov-badge.showtime{background:#D0021B; color:#fff}
-  .prov-badge.amc{background:#00FFC2; color:#001}
-  .prov-badge.criterion{background:#E5B24C; color:#1a1200}
-  .prov-badge.tubi{background:#FF0049; color:#fff}
-  .prov-badge.pluto{background:#6D4AFF; color:#fff}
-  .ratings{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
-  .sublabel{color:var(--muted);font-size:13px}
-  .footer{display:flex;gap:8px; padding:12px; border-top:1px solid #202532; align-items:center}
-  .disclaimer{font-size:12px;color:#98a7b7;line-height:1.4}
-</style>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <header>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,55 @@
+:root { --radius:14px; --pad:14px; --bg:#0f1115; --card:#171a21; --ink:#e8ecf1; --muted:#a9b4c0; --accent:#7cf; --header-pad:22px; --header-height:72px; }
+*{box-sizing:border-box;font-family:ui-sans-serif,system-ui,Segoe UI,Apple Color Emoji,Arial}
+body{margin:0;background:linear-gradient(180deg,#0c0f13,#10131a 40%,#0f1115);color:var(--ink);font-size:16px}
+header{padding:var(--header-pad) var(--pad); position:sticky; top:0; backdrop-filter: blur(10px); background:#0f1115cc; border-bottom:1px solid #222; min-height:var(--header-height)}
+h1{margin:0;font-size:28px;letter-spacing:0.5px;font-family:'Bungee', system-ui;line-height:1}
+.brand{display:flex;gap:10px;align-items:center}
+.brand .title-text{background:linear-gradient(90deg,#7cf,#48c,#8ef); background-clip:text; -webkit-background-clip:text; color:transparent; text-shadow:0 2px 16px rgba(124,255,255,0.15)}
+main{padding:var(--pad);max-width:940px;margin:0 auto}
+.panel{background:var(--card); border:1px solid #222; border-radius:var(--radius); padding:var(--pad); margin-bottom:16px}
+.row{display:flex;gap:10px;flex-wrap:wrap}
+.chip{padding:8px 12px; border:1px solid #2a2f39; border-radius:999px; cursor:pointer; user-select:none}
+.chip input{display:none}
+.chip.active{border-color:var(--accent); box-shadow:0 0 0 2px #7cf3 inset}
+label{display:block;margin:8px 0 4px;font-weight:600;color:#dbe3ec}
+select, input[type="range"], input[type="text"]{width:100%; background:#0f1218; color:var(--ink); border:1px solid #2a2f39; border-radius:10px; padding:10px}
+button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer}
+.btn{background:linear-gradient(135deg,#48c,#7cf); color:#02111f}
+.btn.secondary{background:#1e2430;color:#cfe7ff;border:1px solid #2a323e}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr)); gap:14px}
+.card{background:#0d1118;border:1px solid #202532;border-radius:16px;overflow:hidden;display:flex;flex-direction:column}
+.poster{aspect-ratio:2/3;background:#0a0d12;object-fit:cover;width:100%}
+.meta{padding:12px}
+.title{font-weight:800;line-height:1.2;margin:0 0 6px}
+.badges{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0}
+.badge{font-size:12px;padding:6px 8px;border:1px solid #2a2f39;border-radius:999px;color:#cfe3ff}
+.provline{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0}
+.prov-badge{font-size:12px;padding:6px 10px;border-radius:999px;font-weight:800;border:1px solid transparent}
+.prov-badge.netflix{background:#E50914; color:#fff}
+.prov-badge.prime,.prov-badge.amazon{background:#00A8E1; color:#001}
+.prov-badge.freevee{background:#A5E000; color:#081}
+.prov-badge.disney{background:#113CCF; color:#fff}
+.prov-badge.hulu{background:#1CE783; color:#021}
+.prov-badge.max{background:#5B61F6; color:#fff}
+.prov-badge.appletv{background:#a3aaae; color:#111}
+.prov-badge.paramount{background:#0064FF; color:#fff}
+.prov-badge.peacock{background:#1f1f1f; color:#fff; border-color:#444}
+.prov-badge.starz{background:#0b0d10; color:#d4f7ff}
+.prov-badge.showtime{background:#D0021B; color:#fff}
+.prov-badge.amc{background:#00FFC2; color:#001}
+.prov-badge.criterion{background:#E5B24C; color:#1a1200}
+.prov-badge.tubi{background:#FF0049; color:#fff}
+.prov-badge.pluto{background:#6D4AFF; color:#fff}
+.ratings{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+.sublabel{color:var(--muted);font-size:13px}
+.footer{display:flex;gap:8px; padding:12px; border-top:1px solid #202532; align-items:center}
+.disclaimer{font-size:12px;color:#98a7b7;line-height:1.4}
+@media (max-width: 640px){
+  body{font-size:14px;}
+  :root{--pad:10px; --header-pad:16px; --header-height:60px;}
+}
+@media (min-width: 1024px){
+  body{font-size:18px;}
+  :root{--pad:20px; --header-pad:28px; --header-height:88px;}
+}
+


### PR DESCRIPTION
## Summary
- move inline style block from `index.html` into new `styles.css`
- add mobile and desktop media queries to adjust base font size, header height, and padding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c2f273218832dbf4587d6abdffc50