### PR TITLE
Add responsive layout wrapper for questionnaire and results

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,67 +17,69 @@
 </header>
 <main>
 
-  <!-- Stepper -->
-  <div class="panel" id="questionnaire">
-    <div class="row" style="align-items:flex-end; gap:14px">
-      <div style="flex:1;min-width:180px">
-        <label>Movie or TV?</label>
-        <div class="row" id="typeChips">
-          <div class="chip active" data-value="movie">Movie</div>
-          <div class="chip" data-value="tv">TV</div>
+  <div class="layout">
+    <!-- Stepper -->
+    <div class="panel" id="questionnaire">
+      <div class="row" style="align-items:flex-end; gap:14px">
+        <div style="flex:1;min-width:180px">
+          <label>Movie or TV?</label>
+          <div class="row" id="typeChips">
+            <div class="chip active" data-value="movie">Movie</div>
+            <div class="chip" data-value="tv">TV</div>
+          </div>
+        </div>
+
+        <div style="flex:2;min-width:240px">
+          <label>Genres (pick a few)</label>
+          <div class="row" id="genreChips"></div>
+        </div>
+
+        <div style="flex:1;min-width:180px">
+          <label>Release window</label>
+          <select id="releaseWindow">
+            <option value="">Anything</option>
+            <option value="new">New (last 2 years)</option>
+            <option value="recent">2015–2021</option>
+            <option value="classic">Before 2015</option>
+          </select>
         </div>
       </div>
 
-      <div style="flex:2;min-width:240px">
-        <label>Genres (pick a few)</label>
-        <div class="row" id="genreChips"></div>
+      <div class="row" style="margin-top:12px">
+        <div style="flex:2;min-width:240px">
+          <label>Streaming services (US)</label>
+          <div class="row" id="providerChips" style="max-height:112px; overflow:auto"></div>
+          <div class="sublabel">Tip: pick the services you actually subscribe to.</div>
+        </div>
+
+        <div style="flex:1;min-width:200px">
+          <label>Minimum community rating (IMDb)</label>
+          <input id="minImdb" type="range" min="0" max="9" step="0.5" value="6.5" oninput="minImdbOut.textContent=this.value">
+          <div class="sublabel">≥ <span id="minImdbOut">6.5</span>/10</div>
+        </div>
+
+        <div style="flex:1;min-width:200px">
+          <label>Vibe</label>
+          <select id="mood">
+            <option value="">Surprise us</option>
+            <option value="feelgood">Feel-good</option>
+            <option value="intense">Intense / thrilling</option>
+            <option value="smart">Smart / talky</option>
+            <option value="spooky">Spooky</option>
+            <option value="actiony">Action-packed</option>
+          </select>
+        </div>
       </div>
 
-      <div style="flex:1;min-width:180px">
-        <label>Release window</label>
-        <select id="releaseWindow">
-          <option value="">Anything</option>
-          <option value="new">New (last 2 years)</option>
-          <option value="recent">2015–2021</option>
-          <option value="classic">Before 2015</option>
-        </select>
-      </div>
-    </div>
-
-    <div class="row" style="margin-top:12px">
-      <div style="flex:2;min-width:240px">
-        <label>Streaming services (US)</label>
-        <div class="row" id="providerChips" style="max-height:112px; overflow:auto"></div>
-        <div class="sublabel">Tip: pick the services you actually subscribe to.</div>
-      </div>
-
-      <div style="flex:1;min-width:200px">
-        <label>Minimum community rating (IMDb)</label>
-        <input id="minImdb" type="range" min="0" max="9" step="0.5" value="6.5" oninput="minImdbOut.textContent=this.value">
-        <div class="sublabel">≥ <span id="minImdbOut">6.5</span>/10</div>
-      </div>
-
-      <div style="flex:1;min-width:200px">
-        <label>Vibe</label>
-        <select id="mood">
-          <option value="">Surprise us</option>
-          <option value="feelgood">Feel-good</option>
-          <option value="intense">Intense / thrilling</option>
-          <option value="smart">Smart / talky</option>
-          <option value="spooky">Spooky</option>
-          <option value="actiony">Action-packed</option>
-        </select>
+      <div class="row" style="margin-top:14px">
+        <button class="btn" id="findBtn">Find something to watch</button>
+        <button class="btn secondary" id="shuffleBtn" title="Show different matches">Roll again</button>
       </div>
     </div>
 
-    <div class="row" style="margin-top:14px">
-      <button class="btn" id="findBtn">Find something to watch</button>
-      <button class="btn secondary" id="shuffleBtn" title="Show different matches">Roll again</button>
-    </div>
+    <!-- Results -->
+    <div id="results" class="grid"></div>
   </div>
-
-  <!-- Results -->
-  <div id="results" class="grid"></div>
   <div id="status" class="sublabel"></div>
 
   <div class="panel">

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,7 @@ h1{margin:0;font-size:28px;letter-spacing:0.5px;font-family:'Bungee', system-ui;
 .brand .title-text{background:linear-gradient(90deg,#7cf,#48c,#8ef); background-clip:text; -webkit-background-clip:text; color:transparent; text-shadow:0 2px 16px rgba(124,255,255,0.15)}
 main{padding:var(--pad);max-width:940px;margin:0 auto}
 .panel{background:var(--card); border:1px solid #222; border-radius:var(--radius); padding:var(--pad); margin-bottom:16px}
+.layout{display:block}
 .row{display:flex;gap:10px;flex-wrap:wrap}
 .chip{padding:8px 12px; border:1px solid #2a2f39; border-radius:999px; cursor:pointer; user-select:none}
 .chip input{display:none}
@@ -51,5 +52,8 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
 @media (min-width: 1024px){
   body{font-size:18px;}
   :root{--pad:20px; --header-pad:28px; --header-height:88px;}
+  .layout{display:flex;gap:20px;}
+  .layout #questionnaire{flex:0 0 30%;}
+  .layout #results{flex:1;}
 }
 


### PR DESCRIPTION
## Summary
- Wrap questionnaire and results sections in a new `.layout` container
- Add responsive CSS that stacks on mobile and displays side-by-side with gap on desktop
- Use CSS rules to control panel widths instead of inline styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c305cb504832daff80d7467160f83