### PR TITLE
Move seen list toggle button to floating control

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
 <header>
   <div class="brand">
     <h1 class="title-text">📺 StreamPal</h1>
-    <button id="toggleSeen" class="btn secondary">Seen list</button>
   </div>
 </header>
 <main>
@@ -94,6 +93,7 @@
       Data © TMDb; watch-provider availability powered by TMDb’s JustWatch partnership. Ratings via OMDb (IMDb & Rotten Tomatoes when available).
     </div>
   </div>
+  <button id="toggleSeen" class="btn secondary seen-btn-fixed">Seen list</button>
 </main>
 
 <script type="module">
@@ -175,7 +175,10 @@ $("#findBtn").addEventListener("click", ()=> { state.pageCursor = 1; discover(fa
 $("#toggleSeen").addEventListener("click",()=>{
   const panel = $("#seenList");
   panel.hidden = !panel.hidden;
-  if(!panel.hidden) renderSeenList();
+  if(!panel.hidden){
+    renderSeenList();
+    document.querySelector('#seenList').scrollIntoView({ behavior: 'smooth' });
+  }
 });
 $("#resetListsBtn").addEventListener("click",()=>{
   state.seen.clear();

--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
 body{margin:0;background:linear-gradient(180deg,#0c0f13,#10131a 40%,#0f1115);color:var(--ink);font-size:16px}
 header{padding:var(--header-pad) var(--pad); position:sticky; top:0; backdrop-filter: blur(10px); background:#0f1115cc; border-bottom:1px solid #222; min-height:var(--header-height)}
 h1{margin:0;font-size:28px;letter-spacing:0.5px;font-family:'Bungee', system-ui;line-height:1}
-.brand{display:flex;gap:10px;align-items:center}
+.brand{display:flex;align-items:center}
 .brand .title-text{background:linear-gradient(90deg,#7cf,#48c,#8ef); background-clip:text; -webkit-background-clip:text; color:transparent; text-shadow:0 2px 16px rgba(124,255,255,0.15)}
 main{padding:var(--pad);max-width:940px;margin:0 auto}
 .panel{background:var(--card); border:1px solid #222; border-radius:var(--radius); padding:var(--pad); margin-bottom:16px}
@@ -22,6 +22,7 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
 .btn{background:linear-gradient(135deg,#48c,#7cf); color:#02111f}
 .btn.secondary{background:#1e2430;color:#cfe7ff;border:1px solid #2a323e}
 .icon-btn{padding:8px 10px}
+.seen-btn-fixed{position:fixed;right:var(--pad);bottom:var(--pad)}
 .grid{display:grid;grid-template-columns:1fr;gap:14px}
 #seenList{display:none;}
 #seenList:not([hidden]){display:block;}


### PR DESCRIPTION
## Summary
- Relocate seen list toggle button below main content and style it as fixed bottom-right
- Smooth-scroll to the seen list after toggling
- Remove unnecessary header gap and add fixed button CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d19e239c4832d82e24867033f5667