### PR TITLE
feat: add filter drawer

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,14 @@
   <div class="brand">
     <h1 class="title-text">📺 StreamPal</h1>
   </div>
+  <button id="filtersBtn" class="btn secondary">Filters</button>
 </header>
 <main>
 
   <div class="layout">
     <!-- Stepper -->
-    <div class="panel" id="questionnaire">
+    <aside id="filterDrawer" class="drawer">
+      <div class="panel" id="questionnaire">
       <div class="row row--inputs">
         <div style="flex:1;min-width:180px">
           <label>Movie or TV?</label>
@@ -71,11 +73,12 @@
         </div>
       </div>
 
-      <div class="row row--actions">
-        <button class="btn" id="findBtn">Find something to watch</button>
-        <button class="btn secondary" id="shuffleBtn" title="Show different matches">Roll again</button>
+        <div class="row row--actions">
+          <button class="btn" id="findBtn">Find something to watch</button>
+          <button class="btn secondary" id="shuffleBtn" title="Show different matches">Roll again</button>
+        </div>
       </div>
-    </div>
+    </aside>
 
     <!-- Results -->
     <div id="results" class="grid"></div>
@@ -170,8 +173,23 @@ document.addEventListener("click",(e)=>{
   if(e.target.classList.contains("chip")) toggleChip(e.target);
 });
 
-$("#shuffleBtn").addEventListener("click", ()=> discover(true));
-$("#findBtn").addEventListener("click", ()=> { state.pageCursor = 1; discover(false); });
+const drawer = $("#filterDrawer");
+const filtersBtn = $("#filtersBtn");
+filtersBtn.addEventListener("click", () => {
+  const open = drawer.classList.toggle("drawer--open");
+  if(!open) filtersBtn.focus();
+});
+$("#shuffleBtn").addEventListener("click", ()=> {
+  drawer.classList.remove("drawer--open");
+  discover(true);
+  filtersBtn.focus();
+});
+$("#findBtn").addEventListener("click", ()=> {
+  drawer.classList.remove("drawer--open");
+  state.pageCursor = 1;
+  discover(false);
+  filtersBtn.focus();
+});
 $("#toggleSeen").addEventListener("click",()=>{
   const panel = $("#seenList");
   panel.hidden = !panel.hidden;

--- a/styles.css
+++ b/styles.css
@@ -1,13 +1,15 @@
 :root { --radius:14px; --pad:14px; --bg:#0f1115; --card:#171a21; --ink:#e8ecf1; --muted:#a9b4c0; --accent:#7cf; --header-pad:22px; --header-height:72px; }
 *{box-sizing:border-box;font-family:ui-sans-serif,system-ui,Segoe UI,Apple Color Emoji,Arial}
 body{margin:0;background:linear-gradient(180deg,#0c0f13,#10131a 40%,#0f1115);color:var(--ink);font-size:16px}
-header{padding:var(--header-pad) var(--pad); position:sticky; top:0; backdrop-filter: blur(10px); background:#0f1115cc; border-bottom:1px solid #222; min-height:var(--header-height)}
+header{padding:var(--header-pad) var(--pad); position:sticky; top:0; backdrop-filter: blur(10px); background:#0f1115cc; border-bottom:1px solid #222; min-height:var(--header-height);display:flex;align-items:center;justify-content:space-between}
 h1{margin:0;font-size:28px;letter-spacing:0.5px;font-family:'Bungee', system-ui;line-height:1}
 .brand{display:flex;align-items:center}
 .brand .title-text{background:linear-gradient(90deg,#7cf,#48c,#8ef); background-clip:text; -webkit-background-clip:text; color:transparent; text-shadow:0 2px 16px rgba(124,255,255,0.15)}
 main{padding:var(--pad);max-width:940px;margin:0 auto}
 .panel{background:var(--card); border:1px solid #222; border-radius:var(--radius); padding:var(--pad); margin-bottom:16px}
 .layout{display:block}
+.drawer{position:fixed;top:var(--header-height);left:0;bottom:0;width:80%;max-width:320px;background:var(--bg);transform:translateX(-100%);transition:transform .3s ease;z-index:1000;overflow:auto;padding:var(--pad)}
+.drawer.drawer--open{transform:translateX(0)}
 .row{display:flex;gap:10px;flex-wrap:wrap}
 .row--inputs{align-items:flex-end;gap:14px}
 .row--inputs + .row--inputs{margin-top:12px}
@@ -72,8 +74,10 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
 @media (min-width: 1024px){
   body{font-size:18px;}
   :root{--pad:20px; --header-pad:28px; --header-height:88px;}
+  #filtersBtn{display:none;}
+  .drawer{position:static;transform:none;width:auto;max-width:none;padding:0;}
   .layout{display:flex;gap:20px;}
-  .layout #questionnaire{flex:0 0 30%;}
+  .layout .drawer{flex:0 0 30%;}
   .layout #results{flex:1;}
   .grid{grid-template-columns:repeat(auto-fill,minmax(260px,1fr));}
   .meta{padding:16px;}


### PR DESCRIPTION
## Summary
- add off-canvas filter drawer with toggle button
- style drawer for mobile overlay and desktop side panel
- wire up drawer toggling and refresh results only after confirming filters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2131cb24832da274226ffd5def5f