### PR TITLE
Add seen list drawer with accessibility enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,10 @@
   <div class="brand">
     <h1 class="title-text">📺 StreamPal</h1>
   </div>
-  <button id="filtersBtn" class="btn secondary">Filters</button>
+  <div class="row">
+    <button id="filtersBtn" class="btn secondary">Filters</button>
+    <button id="seenBtn" class="btn secondary">Seen list</button>
+  </div>
 </header>
 <main>
 
@@ -83,12 +86,14 @@
     <!-- Results -->
     <div id="results" class="grid"></div>
   </div>
-  <div id="seenList" class="panel" hidden>
-    <div class="row row--actions">
-      <button class="btn secondary" id="resetListsBtn">Reset list</button>
+  <aside id="seenDrawer" class="drawer drawer--seen">
+    <div class="panel" id="seenList">
+      <div class="row row--actions">
+        <button class="btn secondary" id="resetListsBtn">Reset list</button>
+      </div>
+      <div id="seenGrid" class="grid"></div>
     </div>
-    <div id="seenGrid" class="grid"></div>
-  </div>
+  </aside>
   <div id="status" class="sublabel"></div>
 
   <div class="panel">
@@ -96,7 +101,6 @@
       Data © TMDb; watch-provider availability powered by TMDb’s JustWatch partnership. Ratings via OMDb (IMDb & Rotten Tomatoes when available).
     </div>
   </div>
-  <button id="toggleSeen" class="btn secondary seen-btn-fixed">Seen list</button>
 </main>
 
 <script type="module">
@@ -143,6 +147,47 @@ function toggleChip(chip){
 function saveSeen(){ localStorage.setItem("seenIds", JSON.stringify([...state.seen])); }
 function saveKept(){ localStorage.setItem("keptIds", JSON.stringify([...state.kept])); }
 
+let activeDrawer = null;
+function setupDrawer(drawerId, btnId, onOpen){
+  const drawer = $(drawerId);
+  const btn = $(btnId);
+  let focusables = [];
+  function trap(e){
+    if(e.key === 'Escape') return close();
+    if(e.key === 'Tab' && focusables.length){
+      const first = focusables[0];
+      const last = focusables[focusables.length-1];
+      if(e.shiftKey && document.activeElement === first){
+        e.preventDefault(); last.focus();
+      } else if(!e.shiftKey && document.activeElement === last){
+        e.preventDefault(); first.focus();
+      }
+    }
+  }
+  function open(){
+    if(activeDrawer && activeDrawer !== api) activeDrawer.close();
+    drawer.classList.add('drawer--open');
+    btn.setAttribute('aria-expanded','true');
+    onOpen && onOpen();
+    focusables = [...drawer.querySelectorAll('a,button,input,select,textarea,[tabindex]:not([tabindex="-1"])')];
+    if(focusables[0]) focusables[0].focus();
+    document.addEventListener('keydown',trap);
+    activeDrawer = api;
+  }
+  function close(){
+    drawer.classList.remove('drawer--open');
+    btn.setAttribute('aria-expanded','false');
+    document.removeEventListener('keydown',trap);
+    btn.focus();
+    if(activeDrawer === api) activeDrawer = null;
+  }
+  btn.addEventListener('click', () => {
+    drawer.classList.contains('drawer--open') ? close() : open();
+  });
+  const api = {open, close};
+  return api;
+}
+
 async function renderSeenList(){
   const grid = $("#seenGrid");
   grid.innerHTML = "";
@@ -173,30 +218,17 @@ document.addEventListener("click",(e)=>{
   if(e.target.classList.contains("chip")) toggleChip(e.target);
 });
 
-const drawer = $("#filterDrawer");
-const filtersBtn = $("#filtersBtn");
-filtersBtn.addEventListener("click", () => {
-  const open = drawer.classList.toggle("drawer--open");
-  if(!open) filtersBtn.focus();
-});
+const filterDrawerCtrl = setupDrawer("#filterDrawer", "#filtersBtn");
+const seenDrawerCtrl = setupDrawer("#seenDrawer", "#seenBtn", renderSeenList);
+
 $("#shuffleBtn").addEventListener("click", ()=> {
-  drawer.classList.remove("drawer--open");
+  filterDrawerCtrl.close();
   discover(true);
-  filtersBtn.focus();
 });
 $("#findBtn").addEventListener("click", ()=> {
-  drawer.classList.remove("drawer--open");
+  filterDrawerCtrl.close();
   state.pageCursor = 1;
   discover(false);
-  filtersBtn.focus();
-});
-$("#toggleSeen").addEventListener("click",()=>{
-  const panel = $("#seenList");
-  panel.hidden = !panel.hidden;
-  if(!panel.hidden){
-    renderSeenList();
-    document.querySelector('#seenList').scrollIntoView({ behavior: 'smooth' });
-  }
 });
 $("#resetListsBtn").addEventListener("click",()=>{
   state.seen.clear();

--- a/styles.css
+++ b/styles.css
@@ -8,7 +8,8 @@ h1{margin:0;font-size:28px;letter-spacing:0.5px;font-family:'Bungee', system-ui;
 main{padding:var(--pad);max-width:940px;margin:0 auto}
 .panel{background:var(--card); border:1px solid #222; border-radius:var(--radius); padding:var(--pad); margin-bottom:16px}
 .layout{display:block}
-.drawer{position:fixed;top:var(--header-height);left:0;bottom:0;width:80%;max-width:320px;background:var(--bg);transform:translateX(-100%);transition:transform .3s ease;z-index:1000;overflow:auto;padding:var(--pad)}
+.drawer{position:fixed;top:var(--header-height);bottom:0;width:80%;max-width:320px;background:var(--bg);transition:transform .3s ease;z-index:1000;overflow:auto;padding:var(--pad);left:0;transform:translateX(-100%)}
+.drawer.drawer--seen{left:auto;right:0;transform:translateX(100%)}
 .drawer.drawer--open{transform:translateX(0)}
 .row{display:flex;gap:10px;flex-wrap:wrap}
 .row--inputs{align-items:flex-end;gap:14px}
@@ -24,10 +25,7 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
 .btn{background:linear-gradient(135deg,#48c,#7cf); color:#02111f}
 .btn.secondary{background:#1e2430;color:#cfe7ff;border:1px solid #2a323e}
 .icon-btn{padding:8px 10px}
-.seen-btn-fixed{position:fixed;right:var(--pad);bottom:var(--pad)}
 .grid{display:grid;grid-template-columns:1fr;gap:14px}
-#seenList{display:none;}
-#seenList:not([hidden]){display:block;}
 #seenGrid{max-height:70vh;overflow:auto}
 .card{background:#0d1118;border:1px solid #202532;border-radius:16px;overflow:hidden;display:flex;flex-direction:column}
 .card.seen{opacity:0.5}
@@ -74,8 +72,8 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
 @media (min-width: 1024px){
   body{font-size:18px;}
   :root{--pad:20px; --header-pad:28px; --header-height:88px;}
-  #filtersBtn{display:none;}
-  .drawer{position:static;transform:none;width:auto;max-width:none;padding:0;}
+  #filtersBtn,#seenBtn{display:none;}
+  .drawer:not(.drawer--seen){position:static;transform:none;width:auto;max-width:none;padding:0;}
   .layout{display:flex;gap:20px;}
   .layout .drawer{flex:0 0 30%;}
   .layout #results{flex:1;}


### PR DESCRIPTION
## Summary
- Add a sidebar drawer to show the seen list and control it with a new button
- Generalize drawer logic with focus trapping and ESC support for both filter and seen panels
- Style drawer component and responsive rules to support both left and right drawers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d23cfd80c832db57b35e80e7b3bd3