### PR TITLE
Improve responsive drawer layout and behavior

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,9 +8,9 @@ h1{margin:0;font-size:28px;letter-spacing:0.5px;font-family:'Bungee', system-ui;
 main{padding:var(--pad);max-width:940px;margin:0 auto}
 .panel{background:var(--card); border:1px solid #222; border-radius:var(--radius); padding:var(--pad); margin-bottom:16px}
 .layout{display:block}
-.drawer{position:fixed;top:var(--header-height);bottom:0;width:80%;max-width:320px;background:var(--bg);transition:transform .3s ease;z-index:1000;overflow:auto;padding:var(--pad);left:0;transform:translateX(-100%)}
+.drawer{position:fixed;top:var(--header-height);bottom:0;width:320px;background:var(--bg);transition:transform .3s ease;z-index:-1;overflow:auto;padding:var(--pad);left:0;transform:translateX(-100%)}
 .drawer.drawer--seen{left:auto;right:0;transform:translateX(100%)}
-.drawer.drawer--open{transform:translateX(0)}
+.drawer.drawer--open{transform:translateX(0);z-index:1000}
 .row{display:flex;gap:10px;flex-wrap:wrap}
 .row--inputs{align-items:flex-end;gap:14px}
 .row--inputs + .row--inputs{margin-top:12px}
@@ -62,6 +62,7 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
   .row--inputs{align-items:stretch}
   .row--inputs>div{min-width:100%!important}
   .row--actions{flex-direction:column;align-items:stretch}
+  .drawer{width:80vw}
 }
 @media (min-width:640px){
   .grid{grid-template-columns:repeat(auto-fill,minmax(200px,1fr));}
@@ -72,10 +73,10 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
 @media (min-width: 1024px){
   body{font-size:18px;}
   :root{--pad:20px; --header-pad:28px; --header-height:88px;}
-  #filtersBtn,#seenBtn{display:none;}
-  .drawer:not(.drawer--seen){position:static;transform:none;width:auto;max-width:none;padding:0;}
+  #filtersBtn{display:none;}
+  .drawer:not(.drawer--seen){position:sticky;top:var(--header-height);height:calc(100vh - var(--header-height));transform:none;width:320px;max-width:none;padding:0;z-index:0;}
   .layout{display:flex;gap:20px;}
-  .layout .drawer{flex:0 0 30%;}
+  .layout .drawer{flex:0 0 320px;}
   .layout #results{flex:1;}
   .grid{grid-template-columns:repeat(auto-fill,minmax(260px,1fr));}
   .meta{padding:16px;}


### PR DESCRIPTION
## Summary
- Make drawers fixed overlays on small screens with transform transition and z-index handling
- Pin filter drawer as a 320px sidebar on large screens and hide the filter button
- Use viewport-based widths for mobile drawers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2581e680832d8fb31f672911be3c