### PR TITLE
fix: prevent mobile zoom on filter drawer

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -28,7 +28,8 @@ export function setupDrawer(drawerId, btnId, onOpen) {
     btn.setAttribute('aria-expanded', 'true');
     onOpen && onOpen();
     focusables = [...drawer.querySelectorAll('a,button,input,select,textarea,[tabindex]:not([tabindex="-1"])')];
-    if (focusables[0]) focusables[0].focus();
+    const isCoarsePointer = window.matchMedia ? window.matchMedia('(pointer: coarse)').matches : false;
+    if (focusables[0] && !isCoarsePointer) focusables[0].focus();
     document.addEventListener('keydown', trap);
     activeDrawer = api;
   }

--- a/tests/drawer.test.js
+++ b/tests/drawer.test.js
@@ -23,4 +23,17 @@ describe('setupDrawer', () => {
     ctrl.close();
     expect(drawer.classList.contains('drawer--open')).toBe(false);
   });
+
+  it('does not focus first element on coarse pointers', () => {
+    document.body.innerHTML = `
+      <button id="btn"></button>
+      <aside id="drawer" class="drawer"><input id="in" /></aside>
+    `;
+    const original = window.matchMedia;
+    window.matchMedia = () => ({ matches: true, addListener() {}, removeListener() {} });
+    const ctrl = setupDrawer('#drawer', '#btn');
+    ctrl.open();
+    expect(document.activeElement.id).not.toBe('in');
+    window.matchMedia = original;
+  });
 });


### PR DESCRIPTION
## Summary
- avoid focusing inputs on touch devices to prevent mobile zoom when opening the filter drawer
- add regression test for coarse-pointer devices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d3b5596bc832d98340ba54d389499