### PR TITLE
chore: remove redundant search button

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
   </div>
   <div class="row">
     <input id="searchInput" type="search" placeholder="Search titles…" />
-    <button id="searchBtn" class="btn">Search</button>
     <button id="filtersBtn" class="btn secondary">Filters</button>
     <button id="seenBtn" class="btn secondary">Seen list</button>
   </div>

--- a/src/app.js
+++ b/src/app.js
@@ -109,7 +109,6 @@ export function initSearch(){
     if(!q) return;
     searchTitles(q);
   };
-  $("#searchBtn").addEventListener("click", go);
   input.addEventListener("keydown", e => { if(e.key === "Enter") go(); });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@ main{padding:var(--pad);max-width:940px;margin:0 auto}
 .chip.active{border-color:var(--accent); box-shadow:0 0 0 2px #7cf3 inset}
 label{display:block;margin:8px 0 4px;font-weight:600;color:#dbe3ec}
 select, input[type="range"], input[type="text"]{width:100%; background:#0f1218; color:var(--ink); border:1px solid #2a2f39; border-radius:10px; padding:10px}
-#searchInput{flex:1 1 160px; background:#0f1218; color:var(--ink); border:1px solid #2a2f39; border-radius:10px; padding:10px}
+#searchInput{flex:1 1 240px; background:#0f1218; color:var(--ink); border:1px solid #2a2f39; border-radius:10px; padding:10px}
 button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer}
 .btn{background:linear-gradient(135deg,#48c,#7cf); color:#02111f}
 .btn.secondary{background:#1e2430;color:#cfe7ff;border:1px solid #2a323e}


### PR DESCRIPTION
## Summary
- Remove search button from header to declutter layout
- Trigger search via Enter key and expand search input width for better spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4746b47c832dba27beb8382e3a3a