### PR TITLE
Fix drawer overlay issue preventing closing

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -7,6 +7,16 @@ export function setupDrawer(drawerId, btnId, onOpen) {
   const btn = $(btnId);
   let focusables = [];
 
+  function positionDrawer() {
+    const header = document.querySelector('header');
+    if (header && drawer) {
+      drawer.style.top = header.offsetHeight + 'px';
+    }
+  }
+
+  positionDrawer();
+  window.addEventListener('resize', positionDrawer);
+
   function trap(e) {
     if (e.key === 'Escape') return close();
     if (e.key === 'Tab' && focusables.length) {

--- a/tests/drawer.test.js
+++ b/tests/drawer.test.js
@@ -36,4 +36,17 @@ describe('setupDrawer', () => {
     expect(document.activeElement.id).not.toBe('in');
     window.matchMedia = original;
   });
+
+  it('positions drawer below the actual header height', () => {
+    document.body.innerHTML = `
+      <header id="hdr"></header>
+      <button id="btn"></button>
+      <aside id="drawer" class="drawer"></aside>
+    `;
+    const header = document.getElementById('hdr');
+    Object.defineProperty(header, 'offsetHeight', { configurable: true, value: 120 });
+    setupDrawer('#drawer', '#btn');
+    const drawer = document.getElementById('drawer');
+    expect(drawer.style.top).toBe('120px');
+  });
 });


### PR DESCRIPTION
## Summary
- Position popout drawers below the true header height and update on resize
- Cover this dynamic layout behavior with a new drawer test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d4b484ea0832daff57b1c792c7737