### PR TITLE
feat: implement responsive header

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,14 +10,24 @@
 <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-<header>
-  <div class="brand">
-    <h1 class="title-text">📺 StreamPal</h1>
-  </div>
-  <div class="row">
-    <input id="searchInput" type="search" placeholder="Search titles…" />
-    <button id="filtersBtn" class="btn secondary">Filters</button>
-    <button id="seenBtn" class="btn secondary">Seen list</button>
+<header id="siteHeader">
+  <div class="header-bar">
+    <div class="header-brand">
+      <h1 class="header-title">📺 StreamPal</h1>
+    </div>
+
+    <button class="btn menu-toggle" id="menuBtn" aria-controls="primaryNav" aria-expanded="false">
+      Menu
+    </button>
+
+    <nav class="header-nav" id="primaryNav" aria-label="Primary">
+      <input id="searchInput" type="search" placeholder="Search titles…" />
+    </nav>
+
+    <div class="header-actions">
+      <button id="filtersBtn" class="btn secondary">Filters</button>
+      <button id="seenBtn" class="btn secondary">Seen list</button>
+    </div>
   </div>
 </header>
 <main>
@@ -107,6 +117,16 @@
 <script type="module">
 import { init } from './src/app.js';
 init();
+</script>
+<script>
+  const header = document.getElementById('siteHeader');
+  const btn = document.getElementById('menuBtn');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      const open = header.classList.toggle('open');
+      btn.setAttribute('aria-expanded', String(open));
+    });
+  }
 </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -85,3 +85,84 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
   .badge,.prov-badge{font-size:14px;}
 }
 
+/* ---- Responsive Header ---- */
+:root{
+  --space: clamp(0.5rem, 1.2vw, 1rem);
+}
+header{
+  padding-block: clamp(0.5rem, 1.2vw, 0.9rem);
+  border-bottom: 1px solid #e9e9e9;
+}
+.header-bar{
+  display: flex;
+  align-items: center;
+  gap: var(--space);
+  flex-wrap: wrap;
+}
+.header-brand{
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  min-width: 12ch;
+}
+.header-brand img{
+  width: clamp(28px, 4vw, 40px);
+  height: auto;
+}
+.header-title{
+  font-weight: 800;
+  font-size: clamp(1rem, 2.4vw, 1.3rem);
+  white-space: nowrap;
+  background:linear-gradient(90deg,#7cf,#48c,#8ef);
+  background-clip:text;
+  -webkit-background-clip:text;
+  color:transparent;
+  text-shadow:0 2px 16px rgba(124,255,255,0.15);
+}
+.header-nav{
+  margin-left: auto;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+.header-nav #searchInput{
+  width: 100%;
+}
+.header-list{
+  display: flex;
+  align-items: center;
+  gap: clamp(.5rem, 2vw, 1rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.header-actions{
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+.btn{
+  border: 1px solid #ddd;
+  background: #fff;
+  padding: .45rem .8rem;
+  border-radius: .5rem;
+  font-weight: 600;
+  line-height: 1;
+}
+/* Mobile toggle hidden by default */
+.menu-toggle{ display: none; }
+
+/* ---- Mobile behavior ---- */
+@media (max-width: 720px){
+  .menu-toggle{ display: inline-flex; margin-left: auto; }
+  .header-nav{ display: none; width: 100%; order: 3; }
+  .header-actions{ order: 2; margin-left: 0; }
+  #siteHeader.open .header-nav{ display: block; }
+  .header-list{
+    flex-direction: column;
+    align-items: flex-start;
+    gap: .6rem;
+    padding-block: .4rem;
+  }
+}
+


### PR DESCRIPTION
## Summary
- refactor header markup with brand, navigation, actions, and mobile toggle button
- add responsive layout styles with flex wrapping and mobile menu
- wire up minimal JS for menu toggle accessibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d5002f328832da5c006206b2a4173