### PR TITLE
Remove menu toggle and ensure mobile search bar displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,6 @@
       <h1 class="header-title">📺 StreamPal</h1>
     </div>
 
-    <button class="btn menu-toggle" id="menuBtn" aria-controls="primaryNav" aria-expanded="false">
-      Menu
-    </button>
-
     <nav class="header-nav" id="primaryNav" aria-label="Primary">
       <input id="searchInput" type="search" placeholder="Search titles…" />
     </nav>
@@ -117,16 +113,6 @@
 <script type="module">
 import { init } from './src/app.js';
 init();
-</script>
-<script>
-  const header = document.getElementById('siteHeader');
-  const btn = document.getElementById('menuBtn');
-  if (btn) {
-    btn.addEventListener('click', () => {
-      const open = header.classList.toggle('open');
-      btn.setAttribute('aria-expanded', String(open));
-    });
-  }
 </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -149,15 +149,10 @@ header{
   font-weight: 600;
   line-height: 1;
 }
-/* Mobile toggle hidden by default */
-.menu-toggle{ display: none; }
-
 /* ---- Mobile behavior ---- */
 @media (max-width: 720px){
-  .menu-toggle{ display: inline-flex; margin-left: auto; }
-  .header-nav{ display: none; width: 100%; order: 3; }
-  .header-actions{ order: 2; margin-left: 0; }
-  #siteHeader.open .header-nav{ display: block; }
+  .header-nav{ display: flex; width: 100%; order: 2; margin-left: 0; }
+  .header-actions{ order: 3; margin-left: 0; }
   .header-list{
     flex-direction: column;
     align-items: flex-start;


### PR DESCRIPTION
## Summary
- remove obsolete mobile menu toggle button and script
- keep header navigation visible and responsive by simplifying mobile CSS

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d56b393c8832dac826e8812a13413