### PR TITLE
Add trending titles section and update search handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,10 @@
     </aside>
 
     <!-- Results -->
-    <div id="results" class="grid"></div>
+    <div id="resultsContainer">
+      <h2 id="resultsHeading">Trending</h2>
+      <div id="results" class="grid"></div>
+    </div>
   </div>
   <aside id="seenDrawer" class="drawer drawer--seen">
     <div class="panel" id="seenList">

--- a/src/app.js
+++ b/src/app.js
@@ -242,7 +242,25 @@ async function attachProviders(items){
   return items;
 }
 
+async function showTrending(){
+  try{
+    const grid = $("#results");
+    grid.innerHTML = "";
+    $("#resultsHeading").textContent = "Trending";
+    const url = `https://api.themoviedb.org/3/trending/${state.type}/week?api_key=${TMDB_KEY}`;
+    const data = await fetchJSON(url);
+    let picks = data.results || [];
+    picks = await enrichWithRatings(picks);
+    picks = await attachProviders(picks);
+    picks.slice(0,8).forEach(p => grid.appendChild(card(p, state, { saveSeen, saveKept })));
+  }catch(e){
+    toast("Failed to load trending titles");
+    console.error(e);
+  }
+}
+
 async function searchTitles(query){
+  $("#resultsHeading").textContent = "";
   try{
     const grid = $("#results");
     const keptEls = [...grid.querySelectorAll('.card.kept')];
@@ -265,6 +283,7 @@ async function searchTitles(query){
 }
 
 export async function discover(nextPage=false){
+  $("#resultsHeading").textContent = "";
   try{
     const grid = $("#results");
     const keptEls = [...grid.querySelectorAll(".card.kept")];
@@ -297,6 +316,7 @@ export async function init(){
   await initFilters();
   initSeenList();
   initSearch();
+  await showTrending();
 }
 
 export default { init, initFilters, initSeenList, initSearch, discover };

--- a/styles.css
+++ b/styles.css
@@ -78,7 +78,7 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
   .drawer:not(.drawer--seen){position:sticky;top:var(--header-height);height:calc(100vh - var(--header-height));transform:none;width:320px;max-width:none;padding:0;z-index:0;}
   .layout{display:flex;gap:20px;}
   .layout .drawer{flex:0 0 320px;}
-  .layout #results{flex:1;}
+  .layout #resultsContainer{flex:1;}
   .grid{grid-template-columns:repeat(auto-fill,minmax(260px,1fr));}
   .meta{padding:16px;}
   .title{font-size:20px;}


### PR DESCRIPTION
## Summary
- Wrap results grid with a container and default "Trending" heading
- Show weekly trending titles on init via new `showTrending` function
- Clear the trending heading when searching or discovering new titles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa99820c8832db5f9fdc823cf90e2