### PR TITLE
Add filter drawer hint animation and ensure mobile trending loads

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -297,6 +297,25 @@ export async function init(){
   await initFilters();
   initSeenList();
   initSearch();
+
+  const btn = $("#filtersBtn");
+  if(!localStorage.getItem("filtersHintSeen")){
+    const clear = () => {
+      btn.classList.remove("filters-hint");
+      localStorage.setItem("filtersHintSeen","1");
+      btn.removeEventListener("click", clear);
+    };
+    btn.classList.add("filters-hint");
+    btn.addEventListener("click", clear);
+    if(filterDrawerCtrl && filterDrawerCtrl.open){
+      const origOpen = filterDrawerCtrl.open;
+      filterDrawerCtrl.open = (...args) => {
+        clear();
+        origOpen(...args);
+      };
+    }
+  }
+  discover();
 }
 
 export default { init, initFilters, initSeenList, initSearch, discover };

--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,8 @@ select, input[type="range"], input[type="text"]{width:100%; background:#0f1218; 
 button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer}
 .btn{background:linear-gradient(135deg,#48c,#7cf); color:#02111f}
 .btn.secondary{background:#1e2430;color:#cfe7ff;border:1px solid #2a323e}
+.filters-hint{border-color:var(--accent);animation:filterPulse 1.5s ease-in-out infinite}
+@keyframes filterPulse{0%,100%{border-color:var(--accent);box-shadow:0 0 8px var(--accent)}50%{border-color:#48c;box-shadow:0 0 0 0 #48c}}
 .icon-btn{padding:8px 10px}
 .grid{display:grid;grid-template-columns:1fr;gap:14px}
 #seenGrid{max-height:70vh;overflow:auto}


### PR DESCRIPTION
## Summary
- Animate Filters button with reusable `.filters-hint` class and `filterPulse` keyframes
- Clear filter hint after first interaction and remember via `localStorage`
- Load initial trending results on init so mobile views populate immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa98bed20832d82bbcd06a81fe078