### PR TITLE
Replace binary logo with SVG wordmark and hover styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,15 +6,15 @@
 <title>StreamPal</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Bungee&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Bungee&family=Montserrat:wght@700&family=Poppins:wght@700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <header id="siteHeader">
-  <div class="header-bar">
-    <div class="header-brand">
-      <h1 class="header-title">📺 StreamPal</h1>
-    </div>
+    <div class="header-bar">
+      <div class="header-brand">
+        <div id="logo"></div>
+      </div>
 
     <nav class="header-nav" id="primaryNav" aria-label="Primary">
       <input id="searchInput" type="search" placeholder="Search titles…" />

--- a/src/StreamPalLogo.js
+++ b/src/StreamPalLogo.js
@@ -1,0 +1,35 @@
+export const StreamPalLogo = ({ size = 36, textSize, color = "#1E6CFB", label = "StreamPal", className = "", gap = 12 } = {}) => {
+  const wordmarkSize = textSize ?? Math.round(size * 0.75);
+  const outer = document.createElement('div');
+  if (className) outer.className = className;
+  outer.setAttribute('aria-label', label);
+  outer.style.display = 'inline-flex';
+  outer.style.alignItems = 'center';
+  outer.style.gap = `${gap}px`;
+  if (color) outer.style.color = color;
+
+  const template = document.createElement('template');
+  template.innerHTML = `
+    <svg width="${size}" height="${size}" viewBox="0 0 128 128" role="img" aria-label="${label} icon" xmlns="http://www.w3.org/2000/svg">
+      <g fill="none" stroke="currentColor" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="16" y="24" width="96" height="72" rx="16" ry="16" />
+        <path d="M56 16 L64 24 M72 16 L64 24" />
+        <path d="M28 104 L36 96 M100 104 L92 96" />
+        <path d="M24 64 C 40 48, 56 56, 64 64 C 72 72, 88 80, 104 64" />
+      </g>
+    </svg>
+    <span style="
+      font-family: Montserrat, Poppins, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', 'Liberation Sans', sans-serif;
+      font-weight: 700;
+      font-size: ${wordmarkSize}px;
+      line-height: 1;
+      letter-spacing: 0.5px;
+    ">
+      Stream<span style="font-weight: 700">Pal</span>
+    </span>
+  `;
+  outer.append(...template.content.childNodes);
+  return outer;
+};
+
+export default StreamPalLogo;

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ import { setupDrawer } from './drawer.js';
 import { fetchJSON } from './fetchJSON.js';
 import { card } from './card.js';
 import { providerSlug } from './providerSlug.js';
+import { StreamPalLogo } from './StreamPalLogo.js';
 
 /*** 🔧 CONFIG — add your keys ***/
 const TMDB_KEY = "f653b3ff00c4561dfaebe995836a28e7";
@@ -294,6 +295,11 @@ export async function discover(nextPage=false){
 }
 
 export async function init(){
+  const slot = document.getElementById("logo");
+  if (slot) {
+    const logo = StreamPalLogo({ className: "header-logo" });
+    slot.replaceWith(logo);
+  }
   await initFilters();
   initSeenList();
   initSearch();

--- a/styles.css
+++ b/styles.css
@@ -105,19 +105,19 @@ header{
   gap: .5rem;
   min-width: 12ch;
 }
-.header-brand img{
-  width: clamp(28px, 4vw, 40px);
-  height: auto;
+.header-logo{
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  color: #1E6CFB;
+  transition: filter .3s ease, transform .3s ease, color .3s ease;
+  flex-shrink: 0;
 }
-.header-title{
-  font-weight: 800;
-  font-size: clamp(1rem, 2.4vw, 1.3rem);
-  white-space: nowrap;
-  background:linear-gradient(90deg,#7cf,#48c,#8ef);
-  background-clip:text;
-  -webkit-background-clip:text;
-  color:transparent;
-  text-shadow:0 2px 16px rgba(124,255,255,0.15);
+
+.header-logo:hover{
+  filter: drop-shadow(0 0 .75rem #0bf);
+  transform: scale(1.05);
+  color: #5595ff;
 }
 .header-nav{
   margin-left: auto;


### PR DESCRIPTION
## Summary
- Replace header placeholder with new `StreamPalLogo` SVG wordmark and remove old icon
- Load supporting fonts and style the logo with hover effects and mobile-friendly sizing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689faa84c218832dbfa8d875d7f87c16