### PR TITLE
Remove global reset from Seen list

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,9 +98,6 @@
   </div>
   <aside id="seenDrawer" class="drawer drawer--seen">
     <div class="panel" id="seenList">
-      <div class="row row--actions">
-        <button class="btn secondary" id="resetListsBtn">Reset list</button>
-      </div>
       <div id="seenGrid" class="grid"></div>
     </div>
   </aside>

--- a/src/app.js
+++ b/src/app.js
@@ -93,14 +93,6 @@ export async function initFilters(){
 
 export function initSeenList(){
   seenDrawerCtrl = setupDrawer("#seenDrawer", "#seenBtn", renderSeenList);
-  $("#resetListsBtn").addEventListener("click",()=>{
-    state.seen.clear();
-    state.kept.clear();
-    localStorage.removeItem("seenIds");
-    localStorage.removeItem("keptIds");
-    $("#seenGrid").innerHTML="";
-    $("#results").innerHTML="";
-  });
 }
 
 export function initSearch(){


### PR DESCRIPTION
## Summary
- Drop Reset list button from the Seen drawer so filtering results remain untouched
- Remove associated handler that cleared seen/kept lists and search results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb8d44404832da60446aa2e4a80b5