### PR TITLE
Add series-based filter for movie and TV results

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,14 +71,11 @@
         </div>
 
         <div style="flex:1;min-width:200px">
-          <label>Vibe</label>
-          <select id="mood">
-            <option value="">Surprise us</option>
-            <option value="feelgood">Feel-good</option>
-            <option value="intense">Intense / thrilling</option>
-            <option value="smart">Smart / talky</option>
-            <option value="spooky">Spooky</option>
-            <option value="actiony">Action-packed</option>
+          <label>Series filter</label>
+          <select id="seriesType">
+            <option value="">Surprise Me!</option>
+            <option value="series">Part of a series / multiple seasons</option>
+            <option value="standalone">Standalone / one season</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace unused vibe dropdown with a series filter
- dynamically show series/standalone options for movies and TV
- filter discovery results by franchise or season count and order results chronologically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a228d101a8832db3e25e44338f3799