### PR TITLE
feat: show related series on card

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -57,7 +57,7 @@ async function renderSeenList(){
       const t = await fetchJSON(`https://api.themoviedb.org/3/${typ}/${id}?api_key=${TMDB_KEY}&language=en-US`);
       t.genre_ids = (t.genres||[]).map(g=>g.id);
       const prev = state.type; state.type = typ;
-      const c = card(t, state, { saveSeen, saveKept });
+      const c = card(t, state, { saveSeen, saveKept, tmdbKey: TMDB_KEY });
       state.type = prev;
       const footer = c.querySelector('.footer');
       const details = footer.querySelector('a');
@@ -260,7 +260,7 @@ async function showTrending(){
     let picks = data.results || [];
     picks = await enrichWithRatings(picks);
     picks = await attachProviders(picks);
-    picks.slice(0,8).forEach(p => grid.appendChild(card(p, state, { saveSeen, saveKept })));
+    picks.slice(0,8).forEach(p => grid.appendChild(card(p, state, { saveSeen, saveKept, tmdbKey: TMDB_KEY })));
   }catch(e){
     toast("Failed to load trending titles");
     console.error(e);
@@ -282,7 +282,7 @@ async function searchTitles(query){
     picks = await enrichWithRatings(picks);
     picks = await attachProviders(picks);
     if(!picks.length){ toast("No results found"); return; }
-    picks.slice(0,8).forEach(p => grid.appendChild(card(p, state, { saveSeen, saveKept })));
+    picks.slice(0,8).forEach(p => grid.appendChild(card(p, state, { saveSeen, saveKept, tmdbKey: TMDB_KEY })));
     toast(`Found ${picks.length} results`);
   }catch(e){
     toast("Search failed");
@@ -338,7 +338,7 @@ export async function discover(nextPage=false){
     picks = await attachProviders(picks);
     state.lastBatch = picks;
     if(!picks.length){ toast("No matches—try lowering the rating or adding providers."); return; }
-    picks.slice(0,8).forEach(p => grid.appendChild(card(p, state, { saveSeen, saveKept })));
+    picks.slice(0,8).forEach(p => grid.appendChild(card(p, state, { saveSeen, saveKept, tmdbKey: TMDB_KEY })));
     toast(`Showing ${Math.min(8,picks.length)} of ${picks.length} matches`);
   }catch(e){
     toast("Oops—API error. Check keys and try again.");

--- a/src/card.js
+++ b/src/card.js
@@ -1,7 +1,8 @@
 import { el } from './dom.js';
 import { providerSlug } from './providerSlug.js';
+import { fetchJSON } from './fetchJSON.js';
 
-export function card(t, state, { saveSeen, saveKept }) {
+export function card(t, state, { saveSeen, saveKept, tmdbKey }) {
   const title = t.title || t.name;
   const year = (t.release_date || t.first_air_date || '').slice(0, 4);
   const poster = t.poster_path ? `https://image.tmdb.org/t/p/w500${t.poster_path}` : '';
@@ -15,6 +16,9 @@ export function card(t, state, { saveSeen, saveKept }) {
 
   const provHTML = (t._providers || []).map(p => `<span class="prov-badge ${providerSlug(p)}">${p}</span>`).join('');
 
+  const showSeries = t.belongs_to_collection || (state.type === 'tv' && (t.number_of_seasons || 0) > 1);
+  const seriesLabel = state.type === 'movie' ? t.belongs_to_collection?.name : 'Series';
+
   const wrap = el('div', { className: 'card' });
   wrap.dataset.id = String(t.id);
   if (state.kept.has(String(t.id))) wrap.classList.add('kept');
@@ -24,6 +28,7 @@ export function card(t, state, { saveSeen, saveKept }) {
       <div class="title">${title} ${year ? `<span class="sublabel">(${year})</span>` : ''}</div>
       <div class="sublabel">${t.overview?.slice(0, 180) ?? ''}${(t.overview || '').length > 180 ? '…' : ''}</div>
       <div class="badges">
+        ${showSeries ? `<span class="badge series-badge">${seriesLabel}</span>` : ''}
         ${g.map(x => `<span class="badge">${x}</span>`).join('')}
       </div>
       ${provHTML ? `<div class="provline">${provHTML}</div>` : ''}
@@ -36,6 +41,30 @@ export function card(t, state, { saveSeen, saveKept }) {
   `;
   const footer = wrap.querySelector('.footer');
   footer.append(seenBtn, keepBtn, detailsBtn);
+
+  if (showSeries) {
+    const badge = wrap.querySelector('.series-badge');
+    badge.addEventListener('click', async () => {
+      const existing = wrap.querySelector('.series-box');
+      if (existing) { existing.remove(); return; }
+      const box = el('div', { className: 'series-box', textContent: 'Loading…' });
+      wrap.appendChild(box);
+      try {
+        if (state.type === 'movie') {
+          const colId = t.belongs_to_collection?.id;
+          const data = await fetchJSON(`https://api.themoviedb.org/3/collection/${colId}?api_key=${tmdbKey}&language=en-US`);
+          const items = (data.parts || []).sort((a,b)=> new Date(a.release_date||0) - new Date(b.release_date||0));
+          box.innerHTML = items.map(m=>`<div class="series-box-item">${m.title} ${(m.release_date||'').slice(0,4)}</div>`).join('');
+        } else {
+          const data = await fetchJSON(`https://api.themoviedb.org/3/tv/${t.id}?api_key=${tmdbKey}&language=en-US`);
+          const items = (data.seasons || []).filter(s=>s.season_number>0).sort((a,b)=> new Date(a.air_date||0) - new Date(b.air_date||0));
+          box.innerHTML = items.map(s=>`<div class="series-box-item">${s.name} ${(s.air_date||'').slice(0,4)}</div>`).join('');
+        }
+      } catch(e) {
+        box.textContent = 'Failed to load series';
+      }
+    });
+  }
 
   seenBtn.addEventListener('click', () => {
     const id = String(t.id);

--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,9 @@ button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight
 .title{font-weight:800;line-height:1.2;margin:0 0 6px;font-size:16px}
 .badges{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0}
 .badge{font-size:11px;padding:6px 8px;border:1px solid #2a2f39;border-radius:999px;color:#cfe3ff}
+.series-badge{cursor:pointer}
+.series-box{padding:8px;border-top:1px solid #202532}
+.series-box-item{margin:4px 0;font-size:14px}
 .provline{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0}
 .prov-badge{font-size:11px;padding:6px 10px;border-radius:999px;font-weight:800;border:1px solid transparent}
 .prov-badge.netflix{background:#E50914; color:#fff}


### PR DESCRIPTION
## Summary
- display a clickable series badge for movies in a collection or shows with multiple seasons
- expand series badge to fetch and list all entries in release order
- pass TMDB key to cards and add basic series styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22b361d58832d84bdbba2cdcef296