### PR TITLE
feat: add roll again button to results

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,14 +82,16 @@
 
         <div class="row row--actions">
           <button class="btn" id="findBtn">Find something to watch</button>
-          <button class="btn secondary" id="shuffleBtn" title="Show different matches">Roll again</button>
         </div>
       </div>
     </aside>
 
     <!-- Results -->
     <div id="resultsContainer">
-      <h2 id="resultsHeading">Trending</h2>
+      <div class="results-toolbar">
+        <h2 id="resultsHeading">Trending</h2>
+        <button class="btn secondary" id="shuffleBtn" title="Show different matches">Roll again</button>
+      </div>
       <div id="results" class="grid"></div>
     </div>
   </div>

--- a/src/app.js
+++ b/src/app.js
@@ -80,7 +80,6 @@ export async function initFilters(){
   filterDrawerCtrl = setupDrawer("#filterDrawer", "#filtersBtn");
 
   $("#shuffleBtn").addEventListener("click", ()=> {
-    filterDrawerCtrl.close();
     discover(true);
   });
   $("#findBtn").addEventListener("click", ()=> {

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,8 @@ main{padding:var(--pad);max-width:940px;margin:0 auto}
 .row--inputs{align-items:flex-end;gap:14px}
 .row--inputs + .row--inputs{margin-top:12px}
 .row--actions{margin-top:14px}
+#resultsContainer .results-toolbar{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;gap:8px;flex-wrap:wrap}
+#resultsContainer .results-toolbar h2{margin:0}
 #providerChips{max-height:112px;overflow:auto}
 .chip{padding:8px 12px; border:1px solid #2a2f39; border-radius:999px; cursor:pointer; user-select:none}
 .chip input{display:none}


### PR DESCRIPTION
## Summary
- move "Roll again" button from filter panel into results area
- add responsive toolbar styling for button and heading
- simplify shuffle handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22ddeb90c832db95553614607af59