### PR TITLE
Reduce header logo footprint on mobile

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -348,7 +348,8 @@ export async function discover(nextPage=false){
 export async function init(){
   const slot = document.getElementById("logo");
   if (slot) {
-    const icon = StreamPalIcon({ size: 180 });
+    // Smaller default icon size to better fit mobile headers
+    const icon = StreamPalIcon({ size: 120 });
     icon.classList.add("header-logo");
     slot.appendChild(icon);
   }

--- a/styles.css
+++ b/styles.css
@@ -118,7 +118,8 @@ header{
   cursor: pointer;
 }
 .header-logo{
-  width: clamp(120px, 20vw, 180px);
+  /* Smaller logo for cleaner mobile layout */
+  width: clamp(80px, 16vw, 120px);
   height: auto;
   color: #1E6CFB;
   transition: filter .3s ease, transform .3s ease, color .3s ease;
@@ -132,7 +133,7 @@ header{
 }
 .header-title{
   font-weight: 800;
-  font-size: clamp(1rem, 2.4vw, 1.3rem);
+  font-size: clamp(0.9rem, 2.2vw, 1.2rem);
   white-space: nowrap;
   background:linear-gradient(90deg,#7cf,#48c,#8ef);
   background-clip:text;


### PR DESCRIPTION
## Summary
- shrink header logo and title text for a compact, uniform header
- adjust default icon size in app initialization to match new styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a234557808832d9893168706bf0f55