### PR TITLE
Show full descriptions in listing cards

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -26,7 +26,7 @@ export function card(t, state, { saveSeen, saveKept, tmdbKey }) {
     <img class="poster" alt="" src="${poster}">
     <div class="meta">
       <div class="title">${title} ${year ? `<span class="sublabel">(${year})</span>` : ''}</div>
-      <div class="sublabel">${t.overview?.slice(0, 180) ?? ''}${(t.overview || '').length > 180 ? '…' : ''}</div>
+      <div class="sublabel">${t.overview ?? ''}</div>
       <div class="badges">
         ${showSeries ? `<span class="badge series-badge">${seriesLabel}</span>` : ''}
         ${g.map(x => `<span class="badge">${x}</span>`).join('')}

--- a/tests/card.test.js
+++ b/tests/card.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { card } from '../src/card.js';
+
+// Ensure card renders the entire overview without truncation
+
+describe('card', () => {
+  it('renders the full overview text', () => {
+    const longText = 'A'.repeat(200);
+    const t = { title: 'Test', overview: longText, id: 1, release_date: '2024-01-01' };
+    const state = { genreMap: { movie: {} }, type: 'movie', kept: new Set(), seen: new Set() };
+    const wrap = card(t, state, { saveSeen() {}, saveKept() {}, tmdbKey: '' });
+    const sublabels = wrap.querySelectorAll('.sublabel');
+    expect(sublabels[1].textContent).toBe(longText);
+  });
+});


### PR DESCRIPTION
## Summary
- Stop truncating overviews so cards show the entire description
- Add test to ensure full overview text is rendered

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27f14797c832d8f22d750f86e3111