### PR TITLE
feat: add Supabase schema and OMDb proxy function

### DIFF
--- a/README_SUPABASE.md
+++ b/README_SUPABASE.md
@@ -1,0 +1,33 @@
+# Supabase Deployment
+
+This project uses Supabase for database tables and edge functions.
+
+## Database schema
+
+1. Install the [Supabase CLI](https://supabase.com/docs/guides/cli) and log in.
+2. Apply the schema:
+   ```bash
+   supabase db push
+   ```
+   or run the SQL file directly:
+   ```bash
+   psql < supabase/sql/schema.sql
+   ```
+
+## OMDb proxy function
+
+1. Set the OMDb API key as a secret:
+   ```bash
+   supabase secrets set OMDB_API_KEY=YOUR_KEY
+   ```
+2. Deploy the function:
+   ```bash
+   supabase functions deploy omdb-proxy
+   ```
+3. To test locally:
+   ```bash
+   supabase functions serve omdb-proxy
+   ```
+
+The function proxies requests to the [OMDb API](https://www.omdbapi.com/) and
+sets CORS headers allowing requests from `https://politivol.github.io`.

--- a/supabase/functions/omdb-proxy/deno.json
+++ b/supabase/functions/omdb-proxy/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "start": "deno run --allow-net --allow-env index.ts"
+  }
+}

--- a/supabase/functions/omdb-proxy/index.ts
+++ b/supabase/functions/omdb-proxy/index.ts
@@ -1,0 +1,40 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+const OMDB_API_KEY = Deno.env.get("OMDB_API_KEY");
+const ALLOWED_ORIGIN = "https://politivol.github.io";
+
+if (!OMDB_API_KEY) {
+  console.error("OMDB_API_KEY is not set");
+}
+
+serve(async (req) => {
+  const headers = new Headers({
+    "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  });
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers });
+  }
+
+  if (req.method !== "GET") {
+    return new Response("Method not allowed", { status: 405, headers });
+  }
+
+  if (!OMDB_API_KEY) {
+    return new Response("Missing OMDB_API_KEY", { status: 500, headers });
+  }
+
+  const url = new URL(req.url);
+  const params = url.searchParams;
+  params.set("apikey", OMDB_API_KEY);
+
+  const omdbUrl = `https://www.omdbapi.com/?${params.toString()}`;
+
+  const res = await fetch(omdbUrl);
+  const body = await res.text();
+
+  headers.set("Content-Type", "application/json");
+  return new Response(body, { status: res.status, headers });
+});

--- a/supabase/sql/schema.sql
+++ b/supabase/sql/schema.sql
@@ -1,0 +1,49 @@
+-- Profiles table stores user information.
+create table if not exists profiles (
+  id uuid primary key references auth.users on delete cascade,
+  username text unique,
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now()
+);
+
+-- Enable Row Level Security and policies for profiles
+alter table profiles enable row level security;
+
+create policy "Public profiles are viewable by everyone" on profiles
+  for select
+  using (true);
+
+create policy "Users can insert their own profile" on profiles
+  for insert
+  with check (auth.uid() = id);
+
+create policy "Users can update their own profile" on profiles
+  for update
+  using (auth.uid() = id);
+
+-- Table for items saved by users
+create table if not exists user_items (
+  id bigserial primary key,
+  user_id uuid references auth.users on delete cascade,
+  item_id text not null,
+  created_at timestamp with time zone default now()
+);
+
+-- Enable Row Level Security and policies for user_items
+alter table user_items enable row level security;
+
+create policy "Users can view their own items" on user_items
+  for select
+  using (auth.uid() = user_id);
+
+create policy "Users can insert their own items" on user_items
+  for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can update their own items" on user_items
+  for update
+  using (auth.uid() = user_id);
+
+create policy "Users can delete their own items" on user_items
+  for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- define profiles and user_items tables with RLS policies
- add OMDb proxy edge function with CORS for https://politivol.github.io
- document Supabase deployment steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a383006ca8832d830bf354b36bbd28