### PR TITLE
Use edge proxy for OMDb requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 VITE_SUPABASE_URL=https://iuyhvmarjfgxykpeufsm.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml1eWh2bWFyamZneHlrcGV1ZnNtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyOTg0MzAsImV4cCI6MjA3MDg3NDQzMH0.g_GqtGOW6ZGtnBjn_LuA6nKnSzQLYXxS6QamQBwe7oQ
 VITE_SITE_URL=https://politivol.github.io/streampal/
+VITE_OMDB_PROXY_URL=https://iuyhvmarjfgxykpeufsm.supabase.co/functions/v1/omdb-proxy

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ It builds the site with Node 20, uploads the `dist` directory, and publishes to 
   ```
 - Set the OMDb API key secret and deploy the edge function:
   ```bash
-  supabase secrets set OMDB_API_KEY=YOUR_KEY
+  supabase secrets set OMDB_KEY=YOUR_KEY
   supabase functions deploy omdb-proxy
+  ```
+- Client code should call the proxy function rather than OMDb directly:
+  ```js
+  fetch(`${import.meta.env.VITE_OMDB_PROXY_URL}?t=The%20Matrix`)
   ```

--- a/README_SUPABASE.md
+++ b/README_SUPABASE.md
@@ -18,7 +18,7 @@ This project uses Supabase for database tables and edge functions.
 
 1. Set the OMDb API key as a secret:
    ```bash
-   supabase secrets set OMDB_API_KEY=YOUR_KEY
+   supabase secrets set OMDB_KEY=YOUR_KEY
    ```
 2. Deploy the function:
    ```bash
@@ -28,6 +28,11 @@ This project uses Supabase for database tables and edge functions.
    ```bash
    supabase functions serve omdb-proxy
    ```
+
+Client code can use the deployed function via an environment variable:
+```js
+fetch(`${import.meta.env.VITE_OMDB_PROXY_URL}?t=The%20Matrix`)
+```
 
 The function proxies requests to the [OMDb API](https://www.omdbapi.com/) and
 sets CORS headers allowing requests from `https://politivol.github.io/streampal/`.

--- a/supabase/functions/omdb-proxy/index.ts
+++ b/supabase/functions/omdb-proxy/index.ts
@@ -1,10 +1,10 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 
-const OMDB_API_KEY = Deno.env.get("OMDB_API_KEY");
+const OMDB_KEY = Deno.env.get("OMDB_KEY");
 const ALLOWED_ORIGIN = "https://politivol.github.io/streampal/";
 
-if (!OMDB_API_KEY) {
-  console.error("OMDB_API_KEY is not set");
+if (!OMDB_KEY) {
+  console.error("OMDB_KEY is not set");
 }
 
 serve(async (req) => {
@@ -22,13 +22,13 @@ serve(async (req) => {
     return new Response("Method not allowed", { status: 405, headers });
   }
 
-  if (!OMDB_API_KEY) {
-    return new Response("Missing OMDB_API_KEY", { status: 500, headers });
+  if (!OMDB_KEY) {
+    return new Response("Missing OMDB_KEY", { status: 500, headers });
   }
 
   const url = new URL(req.url);
   const params = url.searchParams;
-  params.set("apikey", OMDB_API_KEY);
+  params.set("apikey", OMDB_KEY);
 
   const omdbUrl = `https://www.omdbapi.com/?${params.toString()}`;
 


### PR DESCRIPTION
## Summary
- Proxy all OMDb requests through a Supabase edge function using `VITE_OMDB_PROXY_URL`
- Store the OMDb API key in edge-function secret `OMDB_KEY`
- Document proxy usage and environment configuration

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a38bf78ca8832db3546aa35c4e2137