### PR TITLE
feat: add header and container layout

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="12" fill="currentColor"/>
+  <polygon points="10,8 16,12 10,16" fill="#02111f"/>
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import AuthPanel from './components/AuthPanel.jsx';
 import SeenList from './components/SeenList.jsx';
+import Header from './components/Header.jsx';
 import { supabase } from './lib/supabaseClient.js';
 
 function App() {
@@ -17,8 +18,8 @@ function App() {
   }, []);
 
   return (
-    <div>
-      <h1>StreamPal</h1>
+    <div className="container">
+      <Header />
       {session ? <SeenList session={session} /> : <AuthPanel />}
     </div>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,18 @@
+export default function Header() {
+  return (
+    <header>
+      <div className="header-bar">
+        <a href="/" className="header-brand">
+          <img src="/logo.svg" alt="StreamPal logo" className="header-logo" />
+          <span className="header-title">StreamPal</span>
+        </a>
+        <nav className="header-nav">
+          <ul className="header-list">
+            <li><a href="#">Home</a></li>
+            <li><a href="#">Seen</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,8 @@
 :root { --radius:14px; --pad:14px; --bg:#0f1115; --card:#171a21; --ink:#e8ecf1; --muted:#a9b4c0; --accent:#7cf; --header-pad:22px; --header-height:72px; }
 *{box-sizing:border-box;font-family:ui-sans-serif,system-ui,Segoe UI,Apple Color Emoji,Arial}
 body{margin:0;background:linear-gradient(180deg,#0c0f13,#10131a 40%,#0f1115);color:var(--ink);font-size:16px}
-header{padding:var(--header-pad) var(--pad); position:sticky; top:0; backdrop-filter: blur(10px); background:#0f1115cc; border-bottom:1px solid #222; min-height:var(--header-height);display:flex;align-items:center;justify-content:space-between}
+.container{max-width:940px;margin:0 auto;padding:0 var(--pad)}
+header{padding:var(--header-pad) 0; position:sticky; top:0; backdrop-filter: blur(10px); background:#0f1115cc; border-bottom:1px solid #222; min-height:var(--header-height);display:flex;align-items:center;justify-content:space-between}
 h1{margin:0;font-size:28px;letter-spacing:0.5px;font-family:'Bungee', system-ui;line-height:1}
 .brand{display:flex;align-items:center}
 .brand .title-text{background:linear-gradient(90deg,#7cf,#48c,#8ef); background-clip:text; -webkit-background-clip:text; color:transparent; text-shadow:0 2px 16px rgba(124,255,255,0.15)}


### PR DESCRIPTION
## Summary
- add StreamPal header with logo and nav links
- wrap app content in reusable container
- update styles for container and header spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a760dc80832d967a4b874e78a825