### PR TITLE
feat: add TMDB and OMDb API utilities

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,83 @@
+const TMDB_API_KEY = 'f653b3ff00c4561dfaebe995836a28e7';
+const OMDB_API_KEY = '84da1316';
+
+function normalizeProviderName(name) {
+  return name.replace(/\s+with ads/i, '').trim();
+}
+
+function extractProviders(watch) {
+  const us = watch?.results?.US;
+  if (!us) return [];
+  const providerSet = new Set();
+  const groups = ['flatrate', 'rent', 'buy', 'free', 'ads'];
+  for (const g of groups) {
+    for (const p of us[g] || []) {
+      providerSet.add(normalizeProviderName(p.provider_name));
+    }
+  }
+  return Array.from(providerSet);
+}
+
+export async function fetchTrending(mediaType, timeWindow = 'week') {
+  const res = await fetch(`https://api.themoviedb.org/3/trending/${mediaType}/${timeWindow}?api_key=${TMDB_API_KEY}`);
+  const data = await res.json();
+  return (data.results || []).map((r) => ({
+    id: r.id,
+    title: r.title || r.name || '',
+    artwork: r.poster_path ? `https://image.tmdb.org/t/p/w500${r.poster_path}` : null,
+    mediaType: r.media_type,
+  }));
+}
+
+export async function fetchDetails(tmdbId) {
+  const endpoints = ['movie', 'tv'];
+  let detailData;
+  let mediaType;
+  for (const type of endpoints) {
+    const res = await fetch(`https://api.themoviedb.org/3/${type}/${tmdbId}?api_key=${TMDB_API_KEY}&append_to_response=external_ids,watch/providers`);
+    if (res.ok) {
+      detailData = await res.json();
+      mediaType = type;
+      break;
+    }
+  }
+  if (!detailData) throw new Error('Not found');
+
+  const imdbId = detailData.external_ids?.imdb_id;
+  let omdbData = {};
+  if (imdbId) {
+    const omdbRes = await fetch(`http://www.omdbapi.com/?i=${imdbId}&apikey=${OMDB_API_KEY}`);
+    omdbData = await omdbRes.json();
+  }
+
+  const providers = extractProviders(detailData['watch/providers']);
+  const rt = omdbData?.Ratings?.find((r) => r.Source === 'Rotten Tomatoes')?.Value;
+  const rotten = rt ? parseInt(rt.replace('%', ''), 10) : null;
+
+  let series = null;
+  if (detailData.belongs_to_collection) {
+    series = {
+      id: detailData.belongs_to_collection.id,
+      name: detailData.belongs_to_collection.name,
+    };
+  } else if (omdbData.Type === 'series') {
+    series = {
+      name: omdbData.Title,
+      totalSeasons: omdbData.totalSeasons,
+    };
+  }
+
+  return {
+    id: detailData.id,
+    title: detailData.title || detailData.name,
+    artwork: detailData.poster_path ? `https://image.tmdb.org/t/p/w500${detailData.poster_path}` : null,
+    genres: (detailData.genres || []).map((g) => g.name),
+    ratings: {
+      tmdb: detailData.vote_average,
+      rottenTomatoes: rotten,
+    },
+    streaming: providers,
+    series,
+    mediaType,
+  };
+}

--- a/src/lib/api.test.js
+++ b/src/lib/api.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchTrending, fetchDetails } from './api';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('fetchTrending', () => {
+  it('fetches and normalizes trending data', async () => {
+    const mockResponse = {
+      results: [
+        { id: 1, title: 'Movie', poster_path: '/p.jpg', media_type: 'movie' },
+        { id: 2, name: 'Show', poster_path: null, media_type: 'tv' }
+      ]
+    };
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) }));
+    global.fetch = fetchMock;
+
+    const result = await fetchTrending('movie');
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/trending/movie/week'));
+    expect(result).toEqual([
+      {
+        id: 1,
+        title: 'Movie',
+        artwork: 'https://image.tmdb.org/t/p/w500/p.jpg',
+        mediaType: 'movie'
+      },
+      {
+        id: 2,
+        title: 'Show',
+        artwork: null,
+        mediaType: 'tv'
+      }
+    ]);
+  });
+});
+
+describe('fetchDetails', () => {
+  it('combines TMDB and OMDb data and normalizes output', async () => {
+    const tmdbData = {
+      id: 1,
+      title: 'Movie 1',
+      poster_path: '/p1.jpg',
+      genres: [{ id: 1, name: 'Action' }],
+      vote_average: 8.3,
+      external_ids: { imdb_id: 'tt123' },
+      'watch/providers': {
+        results: {
+          US: {
+            flatrate: [
+              { provider_name: 'Netflix with ads' },
+              { provider_name: 'Netflix' },
+              { provider_name: 'Hulu' }
+            ]
+          }
+        }
+      },
+      belongs_to_collection: null
+    };
+    const omdbData = {
+      Title: 'Movie 1',
+      Ratings: [{ Source: 'Rotten Tomatoes', Value: '88%' }],
+      Type: 'series',
+      totalSeasons: '2'
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(tmdbData) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(omdbData) });
+
+    global.fetch = fetchMock;
+
+    const result = await fetchDetails(1);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, expect.stringContaining('/movie/1'));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, expect.stringContaining('omdbapi.com'));
+
+    expect(result).toEqual({
+      id: 1,
+      title: 'Movie 1',
+      artwork: 'https://image.tmdb.org/t/p/w500/p1.jpg',
+      genres: ['Action'],
+      ratings: { tmdb: 8.3, rottenTomatoes: 88 },
+      streaming: ['Netflix', 'Hulu'],
+      series: { name: 'Movie 1', totalSeasons: '2' },
+      mediaType: 'movie'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add API helper for TMDB trending and details with OMDb ratings and provider normalization
- normalize streaming provider names and include series fallback logic
- test fetchTrending and fetchDetails with mocked network calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c0778868832da8d50cafb584f789