### PR TITLE
feat: add header search and filter panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ function App() {
 
   return (
     <div className="container">
-      <Header />
+      <Header session={session} onSession={setSession} />
       {session ? (
         <SeenList session={session} onSession={setSession} />
       ) : (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,9 @@
-export default function Header() {
+import { useState } from 'react';
+import Search from './Search.jsx';
+
+export default function Header({ session, onSession }) {
+  const [showFilters, setShowFilters] = useState(false);
+
   return (
     <header>
       <div className="header-bar">
@@ -6,13 +11,40 @@ export default function Header() {
           <img src="/logo.svg" alt="StreamPal logo" className="header-logo" />
           <span className="header-title">StreamPal</span>
         </a>
-        <nav className="header-nav">
-          <ul className="header-list">
-            <li><a href="#">Home</a></li>
-            <li><a href="#">Seen</a></li>
-          </ul>
-        </nav>
+        <div className="header-search">
+          <Search />
+        </div>
+        <button
+          className="btn secondary"
+          type="button"
+          onClick={() => setShowFilters(true)}
+        >
+          Filter
+        </button>
+        <div className="header-actions">
+          <span className="auth-status">
+            {session ? 'Logged in!' : 'Log in / Create account'}
+          </span>
+          <button className="btn secondary" type="button">
+            Seen
+          </button>
+        </div>
       </div>
+      {showFilters && (
+        <aside className="filter-panel">
+          <div className="row row--actions">
+            <h3>Filters</h3>
+            <button
+              className="btn secondary"
+              type="button"
+              onClick={() => setShowFilters(false)}
+            >
+              Close
+            </button>
+          </div>
+          <p>Filter options go here.</p>
+        </aside>
+      )}
     </header>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -55,3 +55,47 @@ button.secondary {
   color: #cfe7ff;
   border: 1px solid #2a323e;
 }
+
+/* Header */
+.header-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 0;
+}
+
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.header-logo {
+  height: 40px;
+}
+
+.header-search {
+  flex: 1;
+}
+
+.header-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 260px;
+  height: 100%;
+  background: #171a21;
+  border-left: 1px solid #2a2f39;
+  padding: 1rem;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.5);
+}
+


### PR DESCRIPTION
## Summary
- Revamp Header with logo, search, filter panel, and auth status
- Pass session state to Header from App
- Add styles for new header layout and filter panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c16743c0832dba4d845241cdb2ed