### PR TITLE
feat: add sliding filter panel and roll again control

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,10 +2,24 @@ import { useEffect, useState } from 'react';
 import AuthPanel from './components/AuthPanel.jsx';
 import SeenList from './components/SeenList.jsx';
 import Header from './components/Header.jsx';
+import FilterPanel from './components/FilterPanel.jsx';
+import { fetchTrending } from './lib/api.js';
 import { supabase } from './lib/supabaseClient.js';
 
 function App() {
   const [session, setSession] = useState(null);
+  const [showFilters, setShowFilters] = useState(false);
+  const [filters, setFilters] = useState({
+    mediaType: 'movie',
+    genres: [],
+    releaseDate: 'any',
+    providers: [],
+    seriesOnly: false,
+    minTmdb: '',
+    minRotten: '',
+  });
+  const [results, setResults] = useState([]);
+  const [index, setIndex] = useState(0);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -17,9 +31,46 @@ function App() {
     return () => subscription.unsubscribe();
   }, []);
 
+  const applyFilters = async (f) => {
+    setFilters(f);
+    setShowFilters(false);
+    const data = await fetchTrending(f.mediaType || 'movie');
+    setResults(data);
+    setIndex(0);
+  };
+
+  const rollAgain = () => {
+    if (results.length > 0) {
+      setIndex((i) => (i + 1) % results.length);
+    }
+  };
+
   return (
     <div className="container">
-      <Header session={session} onSession={setSession} />
+      <Header session={session} onSession={setSession} onOpenFilters={() => setShowFilters(true)} />
+      {showFilters && (
+        <FilterPanel
+          filters={filters}
+          onApply={applyFilters}
+          onClose={() => setShowFilters(false)}
+        />
+      )}
+      {results.length > 0 && (
+        <div className="panel">
+          <div className="row row--actions">
+            <h2>Results</h2>
+            <button className="btn secondary" type="button" onClick={rollAgain}>
+              Roll Again
+            </button>
+          </div>
+          <div className="result-item">
+            <h3>{results[index].title}</h3>
+            {results[index].artwork && (
+              <img src={results[index].artwork} alt={results[index].title} />
+            )}
+          </div>
+        </div>
+      )}
       {session ? (
         <SeenList session={session} onSession={setSession} />
       ) : (

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from 'react';
+
+const TMDB_API_KEY = 'f653b3ff00c4561dfaebe995836a28e7';
+
+function normalizeProviderName(name) {
+  return name.replace(/\s+with ads/i, '').trim();
+}
+
+export default function FilterPanel({ filters = {}, onApply, onClose }) {
+  const [mediaType, setMediaType] = useState(filters.mediaType || 'movie');
+  const [genreOptions, setGenreOptions] = useState([]);
+  const [selectedGenres, setSelectedGenres] = useState(filters.genres || []);
+  const [releaseDate, setReleaseDate] = useState(filters.releaseDate || 'any');
+  const [providerOptions, setProviderOptions] = useState([]);
+  const [providers, setProviders] = useState(filters.providers || []);
+  const [seriesOnly, setSeriesOnly] = useState(filters.seriesOnly || false);
+  const [minTmdb, setMinTmdb] = useState(filters.minTmdb || '');
+  const [minRotten, setMinRotten] = useState(filters.minRotten || '');
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const fetchMeta = async () => {
+      try {
+        const [movieGenresRes, tvGenresRes] = await Promise.all([
+          fetch(`https://api.themoviedb.org/3/genre/movie/list?api_key=${TMDB_API_KEY}`),
+          fetch(`https://api.themoviedb.org/3/genre/tv/list?api_key=${TMDB_API_KEY}`),
+        ]);
+        const movieGenres = await movieGenresRes.json();
+        const tvGenres = await tvGenresRes.json();
+        const combined = [...(movieGenres.genres || []), ...(tvGenres.genres || [])];
+        const names = Array.from(new Set(combined.map((g) => g.name)));
+        setGenreOptions(names);
+
+        const provRes = await fetch(
+          `https://api.themoviedb.org/3/watch/providers/movie?api_key=${TMDB_API_KEY}&watch_region=US`
+        );
+        const provData = await provRes.json();
+        const provNames = (provData.results || []).map((p) => normalizeProviderName(p.provider_name));
+        setProviderOptions(Array.from(new Set(provNames)));
+      } catch (_) {
+        // ignore
+      }
+    };
+    fetchMeta();
+    setOpen(true);
+  }, []);
+
+  const handleGenres = (e) => {
+    setSelectedGenres(Array.from(e.target.selectedOptions, (o) => o.value));
+  };
+
+  const handleProviders = (e) => {
+    setProviders(Array.from(e.target.selectedOptions, (o) => o.value));
+  };
+
+  const apply = () => {
+    onApply?.({
+      mediaType,
+      genres: selectedGenres,
+      releaseDate,
+      providers,
+      seriesOnly,
+      minTmdb,
+      minRotten,
+    });
+  };
+
+  return (
+    <aside className={`filter-panel ${open ? 'open' : ''}`}>
+      <div className="row row--actions">
+        <h3>Filters</h3>
+        <button className="btn secondary" type="button" onClick={onClose}>
+          Close
+        </button>
+      </div>
+      <div className="filter-group">
+        <label>
+          Media Type
+          <select value={mediaType} onChange={(e) => setMediaType(e.target.value)}>
+            <option value="movie">Movie</option>
+            <option value="tv">TV</option>
+          </select>
+        </label>
+      </div>
+      <div className="filter-group">
+        <label>
+          Genres
+          <select multiple value={selectedGenres} onChange={handleGenres}>
+            {genreOptions.map((g) => (
+              <option key={g} value={g}>
+                {g}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="filter-group">
+        <label>
+          Release Date
+          <select value={releaseDate} onChange={(e) => setReleaseDate(e.target.value)}>
+            <option value="any">Any</option>
+            <option value="past_year">Past Year</option>
+            <option value="older">Older</option>
+          </select>
+        </label>
+      </div>
+      <div className="filter-group">
+        <label>
+          Streaming Providers
+          <select multiple value={providers} onChange={handleProviders}>
+            {providerOptions.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="filter-group">
+        <label>
+          <input
+            type="checkbox"
+            checked={seriesOnly}
+            onChange={(e) => setSeriesOnly(e.target.checked)}
+          />
+          {' '}Series only
+        </label>
+      </div>
+      <div className="filter-group">
+        <label>
+          Min TMDB Score
+          <input
+            type="number"
+            min="0"
+            max="10"
+            step="0.1"
+            value={minTmdb}
+            onChange={(e) => setMinTmdb(e.target.value)}
+          />
+        </label>
+      </div>
+      <div className="filter-group">
+        <label>
+          Min Rotten Tomatoes
+          <input
+            type="number"
+            min="0"
+            max="100"
+            value={minRotten}
+            onChange={(e) => setMinRotten(e.target.value)}
+          />
+        </label>
+      </div>
+      <button className="btn" type="button" onClick={apply}>
+        Search
+      </button>
+    </aside>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,9 +1,6 @@
-import { useState } from 'react';
 import Search from './Search.jsx';
 
-export default function Header({ session, onSession }) {
-  const [showFilters, setShowFilters] = useState(false);
-
+export default function Header({ session, onSession, onOpenFilters }) {
   return (
     <header>
       <div className="header-bar">
@@ -17,7 +14,7 @@ export default function Header({ session, onSession }) {
         <button
           className="btn secondary"
           type="button"
-          onClick={() => setShowFilters(true)}
+          onClick={onOpenFilters}
         >
           Filter
         </button>
@@ -30,21 +27,6 @@ export default function Header({ session, onSession }) {
           </button>
         </div>
       </div>
-      {showFilters && (
-        <aside className="filter-panel">
-          <div className="row row--actions">
-            <h3>Filters</h3>
-            <button
-              className="btn secondary"
-              type="button"
-              onClick={() => setShowFilters(false)}
-            >
-              Close
-            </button>
-          </div>
-          <p>Filter options go here.</p>
-        </aside>
-      )}
     </header>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -97,5 +97,11 @@ button.secondary {
   border-left: 1px solid #2a2f39;
   padding: 1rem;
   box-shadow: -2px 0 8px rgba(0, 0, 0, 0.5);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+}
+
+.filter-panel.open {
+  transform: translateX(0);
 }
 


### PR DESCRIPTION
## Summary
- implement sliding FilterPanel with media type, genre, provider, release date, series toggle, and score inputs
- manage filter state in App and show roll-again button above results
- add CSS for slide-in panel and header hook to open filters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c2d1efe4832db595f5d3ee15fac0