### PR TITLE
Add detailed results list with pinning and series view

### DIFF
--- a/src/components/ResultsList.jsx
+++ b/src/components/ResultsList.jsx
@@ -1,0 +1,61 @@
+export default function ResultsList({
+  results,
+  pinnedIds = new Set(),
+  onSeen,
+  onPin,
+  onRollAgain,
+  onShowSeries,
+}) {
+  return (
+    <div className="panel">
+      <div className="row row--actions">
+        <h2>Results</h2>
+        <button className="btn secondary" type="button" onClick={onRollAgain}>
+          Roll Again
+        </button>
+      </div>
+      <ul className="results-list">
+        {results.map((r) => (
+          <li key={r.id} className="result-card">
+            {r.artwork && <img src={r.artwork} alt={r.title} />}
+            <div className="result-card__body">
+              <h3>{r.title}</h3>
+              {r.releaseDate && <p className="release-date">{r.releaseDate}</p>}
+              {r.genres && (
+                <div className="genres">
+                  {r.genres.map((g) => (
+                    <span key={g} className="badge">
+                      {g}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {r.streaming && (
+                <div className="streaming">
+                  {r.streaming.map((s) => (
+                    <span key={s} className="badge badge--provider">
+                      {s}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {r.series && (
+                <button className="btn link" type="button" onClick={() => onShowSeries(r.series)}>
+                  Series
+                </button>
+              )}
+              <div className="actions">
+                <button className="btn secondary" type="button" onClick={() => onSeen(r.id)}>
+                  Seen it!
+                </button>
+                <button className="btn secondary" type="button" onClick={() => onPin(r.id)}>
+                  {pinnedIds.has(r.id) ? 'Unpin' : 'Pin'}
+                </button>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/SeriesPanel.jsx
+++ b/src/components/SeriesPanel.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { fetchSeriesEntries } from '../lib/series.js';
+
+export default function SeriesPanel({ series, onClose }) {
+  const [entries, setEntries] = useState([]);
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      try {
+        const data = await fetchSeriesEntries(series);
+        if (active) setEntries(data);
+      } catch (e) {
+        if (active) setEntries([]);
+      }
+    };
+    load();
+    return () => {
+      active = false;
+    };
+  }, [series]);
+
+  return (
+    <div className="panel side-panel">
+      <div className="row row--actions">
+        <h2>{series?.name || 'Series'}</h2>
+        <button className="btn secondary" type="button" onClick={onClose}>
+          Close
+        </button>
+      </div>
+      <ul>
+        {entries.map((e) => (
+          <li key={e.id || e.imdbID}>
+            {e.title} {e.releaseDate ? `(${e.releaseDate})` : ''}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -59,11 +59,14 @@ export async function fetchDetails(tmdbId) {
     series = {
       id: detailData.belongs_to_collection.id,
       name: detailData.belongs_to_collection.name,
+      type: 'tmdb',
     };
   } else if (omdbData.Type === 'series') {
     series = {
       name: omdbData.Title,
       totalSeasons: omdbData.totalSeasons,
+      imdbId,
+      type: 'omdb',
     };
   }
 
@@ -71,6 +74,7 @@ export async function fetchDetails(tmdbId) {
     id: detailData.id,
     title: detailData.title || detailData.name,
     artwork: detailData.poster_path ? `https://image.tmdb.org/t/p/w500${detailData.poster_path}` : null,
+    releaseDate: detailData.release_date || detailData.first_air_date || null,
     genres: (detailData.genres || []).map((g) => g.name),
     ratings: {
       tmdb: detailData.vote_average,

--- a/src/lib/api.test.js
+++ b/src/lib/api.test.js
@@ -84,10 +84,11 @@ describe('fetchDetails', () => {
       id: 1,
       title: 'Movie 1',
       artwork: 'https://image.tmdb.org/t/p/w500/p1.jpg',
+      releaseDate: null,
       genres: ['Action'],
       ratings: { tmdb: 8.3, rottenTomatoes: 88 },
       streaming: ['Netflix', 'Hulu'],
-      series: { name: 'Movie 1', totalSeasons: '2' },
+      series: { name: 'Movie 1', totalSeasons: '2', imdbId: 'tt123', type: 'omdb' },
       mediaType: 'movie'
     });
   });

--- a/src/lib/series.js
+++ b/src/lib/series.js
@@ -1,0 +1,33 @@
+const TMDB_API_KEY = 'f653b3ff00c4561dfaebe995836a28e7';
+const OMDB_API_KEY = '84da1316';
+
+export async function fetchSeriesEntries(series) {
+  if (!series) return [];
+  if (series.type === 'tmdb' && series.id) {
+    const res = await fetch(`https://api.themoviedb.org/3/collection/${series.id}?api_key=${TMDB_API_KEY}`);
+    const data = await res.json();
+    const parts = data.parts || [];
+    return parts
+      .filter((p) => p.release_date)
+      .sort((a, b) => new Date(a.release_date) - new Date(b.release_date))
+      .map((p) => ({ id: p.id, title: p.title || p.name, releaseDate: p.release_date }));
+  }
+  if (series.type === 'omdb' && series.imdbId) {
+    const results = [];
+    const total = Number(series.totalSeasons) || 0;
+    for (let season = 1; season <= total; season++) {
+      const res = await fetch(`http://www.omdbapi.com/?i=${series.imdbId}&Season=${season}&apikey=${OMDB_API_KEY}`);
+      const data = await res.json();
+      if (data?.Episodes) {
+        for (const ep of data.Episodes) {
+          results.push({
+            imdbID: ep.imdbID,
+            title: `S${season}E${ep.Episode} - ${ep.Title}`,
+          });
+        }
+      }
+    }
+    return results;
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary
- show detailed result cards with poster, metadata and actions
- support pinning items and rerolling to replace unpinned entries
- add series side panel pulling ordered entries from TMDB collections or OMDb

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c43bc10c832d8a3d7d18c12b3f8a