### PR TITLE
feat: support guest seen list

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import AuthPanel from './components/AuthPanel.jsx';
 import SeenList from './components/SeenList.jsx';
 import Header from './components/Header.jsx';
 import FilterPanel from './components/FilterPanel.jsx';
@@ -11,6 +10,7 @@ import { supabase } from './lib/supabaseClient.js';
 function App() {
   const [session, setSession] = useState(null);
   const [showFilters, setShowFilters] = useState(false);
+  const [showSeen, setShowSeen] = useState(false);
   const [filters, setFilters] = useState({
     mediaType: 'movie',
     genres: [],
@@ -75,7 +75,11 @@ function App() {
 
   return (
     <div className="container">
-      <Header session={session} onSession={setSession} onOpenFilters={() => setShowFilters(true)} />
+      <Header
+        session={session}
+        onOpenFilters={() => setShowFilters(true)}
+        onOpenSeen={() => setShowSeen(true)}
+      />
       {showFilters && (
         <FilterPanel
           filters={filters}
@@ -95,10 +99,8 @@ function App() {
         />
       )}
       {series && <SeriesPanel series={series} onClose={() => setSeries(null)} />}
-      {session ? (
-        <SeenList session={session} onSession={setSession} />
-      ) : (
-        <AuthPanel onSession={setSession} />
+      {showSeen && (
+        <SeenList session={session} onSession={setSession} onClose={() => setShowSeen(false)} />
       )}
     </div>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import Search from './Search.jsx';
 
-export default function Header({ session, onSession, onOpenFilters }) {
+export default function Header({ session, onOpenFilters, onOpenSeen }) {
   return (
     <header>
       <div className="header-bar">
@@ -22,7 +22,7 @@ export default function Header({ session, onSession, onOpenFilters }) {
           <span className="auth-status">
             {session ? 'Logged in!' : 'Log in / Create account'}
           </span>
-          <button className="btn secondary" type="button">
+          <button className="btn secondary" type="button" onClick={onOpenSeen}>
             Seen
           </button>
         </div>

--- a/src/components/ResultsList.jsx
+++ b/src/components/ResultsList.jsx
@@ -28,11 +28,11 @@ export default function ResultsList({
         .eq('tmdb_id', r.id)
         .eq('list', 'pinned');
     } else {
-      const seen = JSON.parse(localStorage.getItem('seen') || '[]');
-      if (!seen.includes(r.id)) seen.push(r.id);
-      localStorage.setItem('seen', JSON.stringify(seen));
-      const pinned = (JSON.parse(localStorage.getItem('pinned') || '[]')).filter((id) => id !== r.id);
-      localStorage.setItem('pinned', JSON.stringify(pinned));
+      const seen = JSON.parse(sessionStorage.getItem('seen') || '[]');
+      if (!seen.find((i) => i.id === r.id)) seen.push({ id: r.id, payload: { title: r.title } });
+      sessionStorage.setItem('seen', JSON.stringify(seen));
+      const pinned = (JSON.parse(sessionStorage.getItem('pinned') || '[]')).filter((i) => i.id !== r.id);
+      sessionStorage.setItem('pinned', JSON.stringify(pinned));
     }
   };
 
@@ -59,9 +59,10 @@ export default function ResultsList({
           }, { onConflict: 'user_id,tmdb_id,list' });
       }
     } else {
-      const pinned = new Set(JSON.parse(localStorage.getItem('pinned') || '[]'));
-      if (pinned.has(r.id)) pinned.delete(r.id); else pinned.add(r.id);
-      localStorage.setItem('pinned', JSON.stringify(Array.from(pinned)));
+      const pinned = JSON.parse(sessionStorage.getItem('pinned') || '[]');
+      const idx = pinned.findIndex((i) => i.id === r.id);
+      if (idx >= 0) pinned.splice(idx, 1); else pinned.push({ id: r.id, payload: { title: r.title } });
+      sessionStorage.setItem('pinned', JSON.stringify(pinned));
     }
   };
 


### PR DESCRIPTION
## Summary
- centralize session handling in App and share with Header and SeenList
- allow opening SeenList regardless of auth and persist via Supabase or sessionStorage
- update pin/seen logic to store items locally for guests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c6f26050832d8457753331016d2d