### PR TITLE
Use inline StreamPal SVG logo

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -5,8 +5,42 @@ export default function Header({ session, onOpenFilters, onOpenSeen }) {
     <header>
       <div className="header-bar">
         <a href="/" className="header-brand">
-          <img src="/logo.svg" alt="StreamPal logo" className="header-logo" />
-          <span className="header-title">StreamPal</span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 640 160"
+            role="img"
+            aria-label="StreamPal logo"
+            style={{ color: '#1E6CFB', height: '64px' }}
+            className="header-logo"
+          >
+            <title>StreamPal Logo</title>
+            <style>
+              {`text{font-family:'Montserrat','Poppins',system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans','Liberation Sans',sans-serif}`}
+            </style>
+            <g
+              transform="translate(8,8)"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="10"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="0" y="16" width="120" height="90" rx="18" ry="18" />
+              <path d="M50 8 L60 16 M70 8 L60 16" />
+              <path d="M14 118 L28 104 M106 118 L92 104" />
+              <path d="M8 63 C 32 42, 56 52, 64 60 C 72 68, 96 84, 120 63" />
+            </g>
+            <text
+              x="160"
+              y="100"
+              fill="currentColor"
+              fontSize="72"
+              fontWeight="700"
+              letterSpacing="0.5"
+            >
+              Stream<tspan fontWeight="700">Pal</tspan>
+            </text>
+          </svg>
         </a>
         <div className="header-search">
           <Search />

--- a/src/styles.css
+++ b/src/styles.css
@@ -73,7 +73,7 @@ button.secondary {
 }
 
 .header-logo {
-  height: 40px;
+  height: 64px;
 }
 
 .header-search {


### PR DESCRIPTION
## Summary
- swap image and title text for inline StreamPal logo SVG
- update header logo styles for the new size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c96eeab8832da54428f1203d91bb