### PR TITLE
Use OMDb proxy with Supabase auth headers

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,5 +1,6 @@
 const TMDB_API_KEY = 'f653b3ff00c4561dfaebe995836a28e7';
 const OMDB_PROXY = import.meta.env.VITE_OMDB_PROXY_URL;
+const SB_ANON = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 function normalizeProviderName(name) {
   return name.replace(/\s+with ads/i, '').trim();
@@ -49,14 +50,17 @@ export async function fetchDetails(tmdbId) {
     if (OMDB_PROXY) {
       // proxy must include the apikey server-side; we call the proxy via HTTPS
       const url = `${OMDB_PROXY.replace(/\/$/, '')}?i=${encodeURIComponent(imdbId)}`;
-      const omdbRes = await fetch(url);
+      const headers = {};
+      if (SB_ANON) {
+        headers.apikey = SB_ANON;
+        headers.Authorization = `Bearer ${SB_ANON}`;
+      }
+      const omdbRes = await fetch(url, { headers });
       if (omdbRes.ok) {
         omdbData = await omdbRes.json();
       }
     } else {
       // OMDb proxy not configured; skip OMDb fetch to avoid exposing keys in client
-      // You can configure VITE_OMDB_PROXY_URL in the client environment to enable this.
-      // console.warn('OMDB proxy not configured; skipping OMDb fetch');
     }
   }
 

--- a/src/lib/series.js
+++ b/src/lib/series.js
@@ -1,5 +1,6 @@
 const TMDB_API_KEY = 'f653b3ff00c4561dfaebe995836a28e7';
-const OMDB_API_KEY = '84da1316';
+const OMDB_PROXY = import.meta.env.VITE_OMDB_PROXY_URL;
+const SB_ANON = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export async function fetchSeriesEntries(series) {
   if (!series) return [];
@@ -16,7 +17,17 @@ export async function fetchSeriesEntries(series) {
     const results = [];
     const total = Number(series.totalSeasons) || 0;
     for (let season = 1; season <= total; season++) {
-      const res = await fetch(`http://www.omdbapi.com/?i=${series.imdbId}&Season=${season}&apikey=${OMDB_API_KEY}`);
+      if (!OMDB_PROXY) {
+        // Avoid calling OMDb from client when no proxy is configured
+        break;
+      }
+      const url = `${OMDB_PROXY.replace(/\/$/, '')}?i=${encodeURIComponent(series.imdbId)}&Season=${season}`;
+      const res = await fetch(url, {
+        headers: {
+          apikey: SB_ANON || '',
+          Authorization: SB_ANON ? `Bearer ${SB_ANON}` : '',
+        },
+      });
       const data = await res.json();
       if (data?.Episodes) {
         for (const ep of data.Episodes) {


### PR DESCRIPTION
## Summary
- use Supabase-backed OMDb proxy with optional auth headers
- fetch series episodes through the proxy when available
- adjust tests to stub env variables and work with proxy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3e1acdc9c832da6999d0b0a74f595