### PR TITLE
Disable JWT verification for OMDb proxy

### DIFF
--- a/supabase/functions/omdb-proxy/supabase.toml
+++ b/supabase/functions/omdb-proxy/supabase.toml
@@ -1,0 +1,2 @@
+[functions.omdb-proxy]
+verify_jwt = false


### PR DESCRIPTION
## Summary
- disable JWT verification for OMDb proxy edge function so authorization header is not required

## Testing
- `npm test`
- `npx supabase functions deploy omdb-proxy` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e7552ee0832db2e1b56aac8011fc