### PR TITLE
Add account login and seen list dropdown

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import Header from './components/Header.jsx';
 import FilterPanel from './components/FilterPanel.jsx';
 import ResultsList from './components/ResultsList.jsx';
 import SeriesPanel from './components/SeriesPanel.jsx';
+import AuthPanel from './components/AuthPanel.jsx';
 import { fetchTrending, fetchDetails } from './lib/api.js';
 import { supabase } from './lib/supabaseClient.js';
 
@@ -11,6 +12,7 @@ function App() {
   const [session, setSession] = useState(null);
   const [showFilters, setShowFilters] = useState(false);
   const [showSeen, setShowSeen] = useState(false);
+  const [showAuth, setShowAuth] = useState(false);
   const [filters, setFilters] = useState({
     mediaType: 'movie',
     genres: [],
@@ -35,6 +37,10 @@ function App() {
     });
     return () => subscription.unsubscribe();
   }, []);
+
+  useEffect(() => {
+    if (session) setShowAuth(false);
+  }, [session]);
 
   const loadResults = async (f = filters) => {
     const data = await fetchTrending(f.mediaType || 'movie');
@@ -105,6 +111,7 @@ function App() {
         session={session}
         onOpenFilters={() => setShowFilters(true)}
         onOpenSeen={() => setShowSeen(true)}
+        onLogin={() => setShowAuth(true)}
       />
       {showFilters && (
         <FilterPanel
@@ -126,7 +133,19 @@ function App() {
       )}
       {series && <SeriesPanel series={series} onClose={() => setSeries(null)} />}
       {showSeen && (
-        <SeenList session={session} onSession={setSession} onClose={() => setShowSeen(false)} />
+        <SeenList
+          session={session}
+          onSession={setSession}
+          onClose={() => setShowSeen(false)}
+        />
+      )}
+      {showAuth && (
+        <AuthPanel
+          onSession={(s) => {
+            setSession(s);
+            setShowAuth(false);
+          }}
+        />
       )}
     </div>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,11 @@
+import { useState } from 'react';
 import Search from './Search.jsx';
 
-export default function Header({ session, onOpenFilters, onOpenSeen }) {
+export default function Header({ session, onOpenFilters, onOpenSeen, onLogin }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const toggleMenu = () => setMenuOpen((o) => !o);
+
   return (
     <header>
       <div className="header-bar">
@@ -53,12 +58,35 @@ export default function Header({ session, onOpenFilters, onOpenSeen }) {
           Filter
         </button>
         <div className="header-actions">
-          <span className="auth-status">
-            {session ? 'Logged in!' : 'Log in / Create account'}
-          </span>
-          <button className="btn secondary" type="button" onClick={onOpenSeen}>
-            Seen
-          </button>
+          {session ? (
+            <div className="account-menu">
+              <button
+                className="btn secondary"
+                type="button"
+                onClick={toggleMenu}
+              >
+                My Account
+              </button>
+              {menuOpen && (
+                <div className="account-dropdown">
+                  <button
+                    className="btn secondary"
+                    type="button"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onOpenSeen?.();
+                    }}
+                  >
+                    Seen List
+                  </button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <button className="btn secondary" type="button" onClick={onLogin}>
+              Login
+            </button>
+          )}
         </div>
       </div>
     </header>

--- a/src/styles.css
+++ b/src/styles.css
@@ -88,6 +88,25 @@ button.secondary {
     gap: 0.5rem;
   }
 
+  .account-menu {
+    position: relative;
+  }
+
+  .account-dropdown {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    margin-top: 0.5rem;
+    background: #171a21;
+    border: 1px solid #2a323e;
+    border-radius: 4px;
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 100;
+  }
+
   .results-list {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
## Summary
- Show login or account actions in header
- Open authentication panel for account creation
- Access Seen List via My Account dropdown

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3fd6f3840832db96962ee78c9db8e