### PR TITLE
feat: add header auth controls and dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,32 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>StreamPal</title>
+    <link rel="preload" as="image" href="/logo.svg" />
   </head>
   <body>
-    <div id="root"></div>
+    <header class="site-header">
+      <div class="container header-row">
+        <a class="brand" href="/">
+          <img src="/logo.svg" alt="StreamPal" class="brand-logo" />
+          <span class="brand-name">StreamPal</span>
+        </a>
+
+        <button class="nav-toggle" aria-expanded="false" aria-controls="mobile-nav">
+          <span class="sr-only">Toggle menu</span>
+          ☰
+        </button>
+
+        <nav class="nav-actions" id="mobile-nav">
+          <button class="btn" id="filter-btn" type="button">Filter</button>
+          <button class="btn" id="account-btn" type="button" hidden>My Account</button>
+          <button class="btn" id="logout-btn" type="button" hidden>Logout</button>
+          <button class="btn btn-primary" id="login-btn" type="button">Log in</button>
+        </nav>
+      </div>
+    </header>
+    <main class="container">
+      <div id="root"></div>
+    </main>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import SeenList from './components/SeenList.jsx';
-import Header from './components/Header.jsx';
 import FilterPanel from './components/FilterPanel.jsx';
 import ResultsList from './components/ResultsList.jsx';
 import SeriesPanel from './components/SeriesPanel.jsx';
@@ -41,6 +40,20 @@ function App() {
   useEffect(() => {
     if (session) setShowAuth(false);
   }, [session]);
+
+  useEffect(() => {
+    const openFilters = () => setShowFilters(true);
+    const openLogin = () => setShowAuth(true);
+    const openAccount = () => setShowSeen(true);
+    window.addEventListener('open-filters', openFilters);
+    window.addEventListener('open-login', openLogin);
+    window.addEventListener('open-account', openAccount);
+    return () => {
+      window.removeEventListener('open-filters', openFilters);
+      window.removeEventListener('open-login', openLogin);
+      window.removeEventListener('open-account', openAccount);
+    };
+  }, []);
 
   const loadResults = async (f = filters) => {
     const data = await fetchTrending(f.mediaType || 'movie');
@@ -107,12 +120,6 @@ function App() {
 
   return (
     <div className="container">
-      <Header
-        session={session}
-        onOpenFilters={() => setShowFilters(true)}
-        onOpenSeen={() => setShowSeen(true)}
-        onLogin={() => setShowAuth(true)}
-      />
       {showFilters && (
         <FilterPanel
           filters={filters}

--- a/src/components/ResultsList.jsx
+++ b/src/components/ResultsList.jsx
@@ -67,20 +67,28 @@ export default function ResultsList({
   };
 
   return (
-    <div className="panel">
+    <section className="container">
       <div className="row row--actions">
         <h2>Results</h2>
-        <button className="btn secondary" type="button" onClick={onRollAgain}>
+        <button className="btn btn-primary" type="button" onClick={onRollAgain}>
           Roll Again
         </button>
       </div>
-      <ul className="results-list">
+      <ul className="grid">
         {results.map((r) => (
-          <li key={r.id} className="result-card">
-            {r.artwork && <img src={r.artwork} alt={r.title} />}
-            <div className="result-card__body">
-              <h3>{r.title}</h3>
-              {r.releaseDate && <p className="release-date">{r.releaseDate}</p>}
+          <li key={r.id} className="card">
+            {r.artwork && (
+              <img
+                className="card__media"
+                src={r.artwork}
+                alt={r.title}
+                loading="lazy"
+                decoding="async"
+              />
+            )}
+            <div className="card__body">
+              <h3 className="card__title">{r.title}</h3>
+              {r.releaseDate && <p className="card__meta">{r.releaseDate}</p>}
               {r.genres && (
                 <div className="genres">
                   {r.genres.map((g) => (
@@ -100,15 +108,27 @@ export default function ResultsList({
                 </div>
               )}
               {r.series && (
-                <button className="btn link" type="button" onClick={() => onShowSeries(r.series)}>
+                <button
+                  className="btn btn-sm"
+                  type="button"
+                  onClick={() => onShowSeries(r.series)}
+                >
                   Series
                 </button>
               )}
-              <div className="actions">
-                <button className="btn secondary" type="button" onClick={() => handleSeen(r)}>
+              <div className="button-row">
+                <button
+                  className="btn btn-sm"
+                  type="button"
+                  onClick={() => handleSeen(r)}
+                >
                   Seen it!
                 </button>
-                <button className="btn secondary" type="button" onClick={() => handlePin(r)}>
+                <button
+                  className="btn btn-sm"
+                  type="button"
+                  onClick={() => handlePin(r)}
+                >
                   {pinnedIds.has(r.id) ? 'Unpin' : 'Pin'}
                 </button>
               </div>
@@ -116,6 +136,6 @@ export default function ResultsList({
           </li>
         ))}
       </ul>
-    </div>
+    </section>
   );
 }

--- a/src/header.js
+++ b/src/header.js
@@ -1,0 +1,52 @@
+import { supabase } from './lib/supabaseClient.js';
+
+const btn = document.querySelector('.nav-toggle');
+const nav = document.getElementById('mobile-nav');
+const filterBtn = document.getElementById('filter-btn');
+const loginBtn = document.getElementById('login-btn');
+const accountBtn = document.getElementById('account-btn');
+const logoutBtn = document.getElementById('logout-btn');
+
+const closeMenu = () => btn?.setAttribute('aria-expanded', 'false');
+
+if (btn && nav) {
+  btn.addEventListener('click', () => {
+    const open = btn.getAttribute('aria-expanded') === 'true';
+    btn.setAttribute('aria-expanded', String(!open));
+  });
+}
+
+filterBtn?.addEventListener('click', () => {
+  window.dispatchEvent(new Event('open-filters'));
+  closeMenu();
+});
+
+loginBtn?.addEventListener('click', () => {
+  window.dispatchEvent(new Event('open-login'));
+  closeMenu();
+});
+
+accountBtn?.addEventListener('click', () => {
+  window.dispatchEvent(new Event('open-account'));
+  closeMenu();
+});
+
+logoutBtn?.addEventListener('click', async () => {
+  await supabase.auth.signOut();
+  closeMenu();
+});
+
+const toggleAuthButtons = (session) => {
+  if (session) {
+    loginBtn?.setAttribute('hidden', '');
+    accountBtn?.removeAttribute('hidden');
+    logoutBtn?.removeAttribute('hidden');
+  } else {
+    loginBtn?.removeAttribute('hidden');
+    accountBtn?.setAttribute('hidden', '');
+    logoutBtn?.setAttribute('hidden', '');
+  }
+};
+
+supabase.auth.getSession().then(({ data: { session } }) => toggleAuthButtons(session));
+supabase.auth.onAuthStateChange((_event, session) => toggleAuthButtons(session));

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
-import './styles.css';
+import './styles/layout.css';
+import './styles/type.css';
+import './styles/components.css';
+import './styles/cards.css';
+import './header.js';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,0 +1,6 @@
+.grid{display:grid;gap:var(--space-6);grid-template-columns:repeat(auto-fill, minmax(160px, 1fr))}
+.card{display:flex;flex-direction:column;border:1px solid #4b5563;border-radius:var(--radius);overflow:hidden;background:var(--surface)}
+.card__media{aspect-ratio:2/3;background:#4b5563}
+.card__body{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-2)}
+.card__title{font-weight:600;font-size:clamp(.95rem, 1.6vw, 1.05rem);line-height:1.25}
+.card__meta{font-size:.85rem;color:var(--text-muted)}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,0 +1,4 @@
+.button-row{display:grid;grid-auto-flow:column;grid-auto-columns:max-content;gap:var(--space-3)}
+@media (max-width:768px){.button-row{grid-auto-flow:row;grid-auto-rows:auto}}
+.btn-sm{padding:.375rem .6rem;font-size:.9rem}
+.btn-lg{padding:.75rem 1rem;font-size:1.05rem}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,0 +1,36 @@
+:root{
+  --container: clamp(16rem, 90vw, 72rem);
+  --space-1: .25rem; --space-2: .5rem; --space-3: .75rem; --space-4: 1rem;
+  --space-6: 1.5rem; --space-8: 2rem; --radius: .75rem;
+  --brand: #0B66FF; /* tweak as you like */
+  --accent: var(--brand);
+  --bg: #1f2937;
+  --surface: #374151;
+  --text-muted: #9ca3af;
+}
+*{box-sizing:border-box}
+img{max-width:100%;display:block}
+.sr-only{position:absolute;left:-9999px}
+body{background:var(--bg);color:#f9fafb}
+
+.site-header{position:sticky;top:0;background:var(--surface);border-bottom:1px solid #4b5563;z-index:10;padding-top:env(safe-area-inset-top)}
+.container{width:min(100% - 2rem, var(--container));margin-inline:auto}
+.header-row{display:flex;align-items:center;gap:var(--space-4);padding:var(--space-4) 0;color:#f9fafb}
+.brand{display:flex;align-items:center;gap:var(--space-3);text-decoration:none;color:inherit;min-width:0}
+.brand-logo{width:28px;height:28px;flex:0 0 auto}
+.brand-name{font-weight:700;font-size:clamp(1rem, 2.2vw, 1.25rem);text-wrap:balance;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+
+.nav-toggle{margin-left:auto;border:1px solid #4b5563;border-radius:.5rem;padding:.5rem .75rem;background:var(--surface);color:#f9fafb}
+.nav-actions{display:flex;gap:var(--space-3);margin-left:auto}
+.btn{border:1px solid #4b5563;border-radius:.5rem;padding:.5rem .75rem;text-decoration:none;background:var(--surface);color:#f9fafb}
+.btn-primary{background:var(--brand);border-color:var(--brand);color:#fff}
+.is-active{background:var(--brand);border-color:var(--brand);color:#fff}
+
+/* Mobile: collapse actions */
+@media (max-width: 768px){
+  .nav-actions{position:absolute;inset:auto 0 auto 0;top:100%;background:var(--surface);border-bottom:1px solid #4b5563;padding:var(--space-4);display:none;flex-direction:column}
+  .nav-actions > *{width:100%}
+  .nav-toggle[aria-expanded="true"] + .nav-actions{display:flex}
+}
+
+@media (prefers-reduced-motion: reduce){*{animation:none!important;transition:none!important}}

--- a/src/styles/type.css
+++ b/src/styles/type.css
@@ -1,0 +1,4 @@
+html{font-size:16px}
+h1,h2,h3{line-height:1.2;text-wrap:balance}
+p,li{line-height:1.55}
+:root{--fs-1:clamp(1.1rem, 2.4vw, 1.4rem);--fs-2:clamp(.95rem,1.8vw,1.05rem)}


### PR DESCRIPTION
## Summary
- add filter, account, login and logout buttons to the header menu
- wire header buttons to React via custom events and supabase session handling
- apply a medium-dark color scheme to layout and cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4030352f0832db97f796ba2ef20d1