### PR TITLE
Add toast helper and integrate notifications

### DIFF
--- a/src/components/AuthPanel.jsx
+++ b/src/components/AuthPanel.jsx
@@ -1,44 +1,42 @@
 import { useState } from 'react';
 import { supabase } from '../lib/supabaseClient.js';
+import { toast } from '../lib/toast.js';
 
 export default function AuthPanel({ onSession }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [mode, setMode] = useState('magic');
-  const [error, setError] = useState('');
-  const [message, setMessage] = useState('');
 
   const sendMagicLink = async (e) => {
     e.preventDefault();
-    setError('');
-    setMessage('');
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: { emailRedirectTo: import.meta.env.VITE_SITE_URL },
     });
-    if (error) setError(error.message);
-    else setMessage('Check your email for the magic link.');
+    if (error) toast(error.message, 'danger', 5000, 'exclamation-octagon');
+    else toast('Check your email for the magic link.', 'success', 5000, 'info-circle');
   };
 
   const signUp = async (e) => {
     e.preventDefault();
-    setError('');
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: { emailRedirectTo: import.meta.env.VITE_SITE_URL },
     });
-    if (error) setError(error.message);
-    else onSession?.(data.session);
+    if (error) toast(error.message, 'danger', 5000, 'exclamation-octagon');
+    else {
+      toast('Account created successfully.', 'success', 5000, 'check-circle');
+      onSession?.(data.session);
+    }
   };
 
   const signInWithProvider = async (provider) => {
-    setError('');
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
       options: { redirectTo: import.meta.env.VITE_SITE_URL },
     });
-    if (error) setError(error.message);
+    if (error) toast(error.message, 'danger', 5000, 'exclamation-octagon');
   };
 
   return (
@@ -75,8 +73,6 @@ export default function AuthPanel({ onSession }) {
           </sl-button>
         </form>
       )}
-      {error && <p>{error}</p>}
-      {message && <p>{message}</p>}
       <div className="row row--inputs">
         <sl-button
           variant="neutral"

--- a/src/lib/toast.js
+++ b/src/lib/toast.js
@@ -1,0 +1,21 @@
+export function toast(message, variant = 'primary', duration = 3000, icon) {
+  const container = document.getElementById('toasts');
+  if (!container) return;
+
+  const alert = document.createElement('sl-alert');
+  alert.variant = variant;
+  alert.closable = true;
+  alert.duration = duration;
+
+  if (icon) {
+    const iconEl = document.createElement('sl-icon');
+    iconEl.setAttribute('slot', 'icon');
+    iconEl.setAttribute('name', icon);
+    alert.append(iconEl);
+  }
+  alert.append(message);
+
+  container.append(alert);
+  alert.toast();
+  return alert;
+}


### PR DESCRIPTION
## Summary
- add reusable `toast` helper for showing Shoelace alerts
- display toast notifications during sign up/sign in flows
- show success/error toasts when managing seen and pinned lists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a41737c7e4832d88bebb44ded518e0