### PR TITLE
feat: add dropdown menu to header

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import Search from './Search.jsx';
 
 export default function Header({
@@ -8,6 +9,20 @@ export default function Header({
   onLogout,
   onSearch,
 }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    function handleClick(event) {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setMenuOpen(false);
+      }
+    }
+
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, []);
+
   return (
     <header>
       <div className="header-bar">
@@ -59,18 +74,63 @@ export default function Header({
         <div className="header-search">
           <Search onSearch={onSearch} />
         </div>
-        <sl-dropdown class="header-menu">
-          <sl-button slot="trigger" caret>Menu</sl-button>
-          <sl-menu>
-            {session ? (
-              <sl-menu-item onClick={onLogout}>Logout</sl-menu-item>
-            ) : (
-              <sl-menu-item onClick={onLogin}>Login</sl-menu-item>
-            )}
-            <sl-menu-item onClick={onOpenSeen}>Seen List</sl-menu-item>
-            <sl-menu-item onClick={onOpenFilters}>Filter</sl-menu-item>
-          </sl-menu>
-        </sl-dropdown>
+        <div className="header-menu" ref={menuRef}>
+          <button
+            className="menu-button"
+            onClick={() => setMenuOpen((open) => !open)}
+            aria-expanded={menuOpen}
+            aria-haspopup="true"
+          >
+            Menu
+          </button>
+          {menuOpen && (
+            <ul className="menu-dropdown" role="menu">
+              {session ? (
+                <li role="menuitem">
+                  <button
+                    onClick={() => {
+                      onLogout();
+                      setMenuOpen(false);
+                    }}
+                  >
+                    Logout
+                  </button>
+                </li>
+              ) : (
+                <li role="menuitem">
+                  <button
+                    onClick={() => {
+                      onLogin();
+                      setMenuOpen(false);
+                    }}
+                  >
+                    Login
+                  </button>
+                </li>
+              )}
+              <li role="menuitem">
+                <button
+                  onClick={() => {
+                    onOpenSeen();
+                    setMenuOpen(false);
+                  }}
+                >
+                  Seen List
+                </button>
+              </li>
+              <li role="menuitem">
+                <button
+                  onClick={() => {
+                    onOpenFilters();
+                    setMenuOpen(false);
+                  }}
+                >
+                  Filter
+                </button>
+              </li>
+            </ul>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -168,6 +168,46 @@ body {
 
 .header-menu {
   justify-self: end;
+  position: relative;
+}
+
+.menu-button {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text);
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+}
+
+.menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.25rem);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 150px;
+  z-index: 10;
+}
+
+.menu-dropdown li button {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  padding: 0.5rem 1rem;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+}
+
+.menu-dropdown li button:hover {
+  background: var(--color-border);
 }
 
   .filter-panel.open {


### PR DESCRIPTION
## Summary
- replace inline links with dropdown menu button in header
- style new menu and dropdown items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a423783f04832d8579af1e04cb4c56