### PR TITLE
Display auth and seen panels as overlays

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -200,6 +200,7 @@ function App() {
             setSession(s);
             setShowAuth(false);
           }}
+          onClose={() => setShowAuth(false)}
         />
       )}
     </div>

--- a/src/components/AuthPanel.jsx
+++ b/src/components/AuthPanel.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { supabase } from '../lib/supabaseClient.js';
 import { toast } from '../lib/toast.js';
 
-export default function AuthPanel({ onSession }) {
+export default function AuthPanel({ onSession, onClose }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [mode, setMode] = useState('magic');
@@ -40,8 +40,13 @@ export default function AuthPanel({ onSession }) {
   };
 
   return (
-    <div className="panel">
-      <h2>{mode === 'sign_up' ? 'Sign Up' : 'Sign In'}</h2>
+    <div className="panel modal">
+      <div className="row row--actions">
+        <h2>{mode === 'sign_up' ? 'Sign Up' : 'Sign In'}</h2>
+        <sl-button variant="neutral" type="button" onClick={onClose}>
+          Close
+        </sl-button>
+      </div>
       {mode === 'sign_up' ? (
         <form onSubmit={signUp} className="row row--inputs">
           <input

--- a/src/styles.css
+++ b/src/styles.css
@@ -246,3 +246,42 @@ body {
     }
   }
 
+/* General panel styling */
+.panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+/* Sliding side panel */
+.side-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 260px;
+  height: 100%;
+  background: var(--color-surface);
+  border-left: 1px solid var(--color-border);
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.5);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  overflow-y: auto;
+  z-index: 20;
+}
+
+.side-panel.open {
+  transform: translateX(0);
+}
+
+/* Centered modal panel */
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 30;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+


### PR DESCRIPTION
## Summary
- Turn auth panel into a centered modal with a close button
- Slide seen list out from the right as a side panel
- Add shared panel styles for consistent presentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a425b74884832da250bf294ce132bd