### PR TITLE
Filter to major US streaming providers

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
+import {
+  normalizeProviderName,
+  US_STREAMING_PROVIDERS,
+} from '../lib/providers.js';
 
 const TMDB_API_KEY = 'e20c40a6be42cbc9d98052ca3db76926';
-
-function normalizeProviderName(name) {
-  return name.replace(/\s+with ads/i, '').trim();
-}
 
 export default function FilterPanel({ filters = {}, onApply, onClose }) {
   const [mediaType, setMediaType] = useState(filters.mediaType || 'movie');
@@ -35,7 +35,9 @@ export default function FilterPanel({ filters = {}, onApply, onClose }) {
           `https://api.themoviedb.org/3/watch/providers/movie?api_key=${TMDB_API_KEY}&watch_region=US`
         );
         const provData = await provRes.json();
-        const provNames = (provData.results || []).map((p) => normalizeProviderName(p.provider_name));
+        const provNames = (provData.results || [])
+          .map((p) => normalizeProviderName(p.provider_name))
+          .filter((p) => US_STREAMING_PROVIDERS.includes(p));
         setProviderOptions(Array.from(new Set(provNames)));
       } catch (_) {
         // ignore

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,10 +1,8 @@
+import { normalizeProviderName, US_STREAMING_PROVIDERS } from './providers.js';
+
 const TMDB_API_KEY = 'e20c40a6be42cbc9d98052ca3db76926';
 const OMDB_PROXY = import.meta.env.VITE_OMDB_PROXY_URL;
 const SB_ANON = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-function normalizeProviderName(name) {
-  return name.replace(/\s+with ads/i, '').trim();
-}
 
 function extractProviders(watch) {
   const us = watch?.results?.US;
@@ -13,7 +11,8 @@ function extractProviders(watch) {
   const groups = ['flatrate', 'rent', 'buy', 'free', 'ads'];
   for (const g of groups) {
     for (const p of us[g] || []) {
-      providerSet.add(normalizeProviderName(p.provider_name));
+      const name = normalizeProviderName(p.provider_name);
+      if (US_STREAMING_PROVIDERS.includes(name)) providerSet.add(name);
     }
   }
   return Array.from(providerSet);

--- a/src/lib/api.test.js
+++ b/src/lib/api.test.js
@@ -61,8 +61,10 @@ describe('fetchDetails', () => {
           US: {
             flatrate: [
               { provider_name: 'Netflix with ads' },
-              { provider_name: 'Netflix' },
-              { provider_name: 'Hulu' }
+              { provider_name: 'Amazon Prime Video' },
+              { provider_name: 'HBO Max' },
+              { provider_name: 'Hulu' },
+              { provider_name: 'Obscure Provider' }
             ]
           }
         }
@@ -100,7 +102,7 @@ describe('fetchDetails', () => {
       runtime: null,
       genres: ['Action'],
       ratings: { tmdb: 8.3, rottenTomatoes: 88 },
-      streaming: ['Netflix', 'Hulu'],
+      streaming: ['Netflix', 'Prime Video', 'Max', 'Hulu'],
       series: { name: 'Movie 1', totalSeasons: '2', imdbId: 'tt123', type: 'omdb' },
       mediaType: 'movie'
     });

--- a/src/lib/providers.js
+++ b/src/lib/providers.js
@@ -1,0 +1,42 @@
+export const US_STREAMING_PROVIDERS = [
+  'Netflix',
+  'Hulu',
+  'Disney+',
+  'Max',
+  'Prime Video',
+  'Paramount+',
+  'Peacock',
+  'Apple TV+',
+];
+
+const PROVIDER_ALIASES = {
+  'netflix': 'Netflix',
+  'netflix with ads': 'Netflix',
+  'netflix basic with ads': 'Netflix',
+  'hulu': 'Hulu',
+  'disney+': 'Disney+',
+  'disney plus': 'Disney+',
+  'hbo max': 'Max',
+  'hbo go': 'Max',
+  'hbo now': 'Max',
+  'max': 'Max',
+  'amazon prime video': 'Prime Video',
+  'amazon video': 'Prime Video',
+  'amazon prime': 'Prime Video',
+  'paramount+': 'Paramount+',
+  'paramount plus': 'Paramount+',
+  'paramount+ with showtime': 'Paramount+',
+  'peacock tv': 'Peacock',
+  'peacock premium': 'Peacock',
+  'peacock premium plus': 'Peacock',
+  'apple tv+': 'Apple TV+',
+  'apple tv plus': 'Apple TV+',
+  'apple tv': 'Apple TV+',
+};
+
+export function normalizeProviderName(name) {
+  const cleaned = name.toLowerCase().replace(/\s+with ads?/g, '').trim();
+  const canonical = PROVIDER_ALIASES[cleaned];
+  if (canonical) return canonical;
+  return name.replace(/\s+with ads?/i, '').trim();
+}


### PR DESCRIPTION
## Summary
- add list of major US streaming providers and normalize sub-brands
- limit provider extraction and filter options to those services
- extend tests for provider normalization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4282cbaf4832d8f34d691a1daf274