### PR TITLE
Make hidden text click targets look like buttons

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -87,46 +87,58 @@ export default function Header({
             <ul className="menu-dropdown" role="menu">
               {session ? (
                 <li role="menuitem">
-                  <button
+                  <sl-button
+                    variant="neutral"
+                    type="button"
+                    style={{ width: '100%' }}
                     onClick={() => {
                       onLogout();
                       setMenuOpen(false);
                     }}
                   >
                     Logout
-                  </button>
+                  </sl-button>
                 </li>
               ) : (
                 <li role="menuitem">
-                  <button
+                  <sl-button
+                    variant="neutral"
+                    type="button"
+                    style={{ width: '100%' }}
                     onClick={() => {
                       onLogin();
                       setMenuOpen(false);
                     }}
                   >
                     Login
-                  </button>
+                  </sl-button>
                 </li>
               )}
               <li role="menuitem">
-                <button
+                <sl-button
+                  variant="neutral"
+                  type="button"
+                  style={{ width: '100%' }}
                   onClick={() => {
                     onOpenSeen();
                     setMenuOpen(false);
                   }}
                 >
                   Seen List
-                </button>
+                </sl-button>
               </li>
               <li role="menuitem">
-                <button
+                <sl-button
+                  variant="neutral"
+                  type="button"
+                  style={{ width: '100%' }}
                   onClick={() => {
                     onOpenFilters();
                     setMenuOpen(false);
                   }}
                 >
                   Filter
-                </button>
+                </sl-button>
               </li>
             </ul>
           )}

--- a/src/components/ResultsList.jsx
+++ b/src/components/ResultsList.jsx
@@ -100,7 +100,7 @@ export default function ResultsList({
                 </div>
                 {r.series && (
                   <sl-button
-                    variant="text"
+                    variant="neutral"
                     type="button"
                     data-action="details"
                     onClick={() => onShowSeries(r.series)}

--- a/src/styles.css
+++ b/src/styles.css
@@ -196,18 +196,9 @@ body {
   z-index: 10;
 }
 
-.menu-dropdown li button {
-  background: none;
-  border: none;
-  color: var(--color-text);
-  padding: 0.5rem 1rem;
-  text-align: left;
+.menu-dropdown sl-button::part(base) {
   width: 100%;
-  cursor: pointer;
-}
-
-.menu-dropdown li button:hover {
-  background: var(--color-border);
+  justify-content: flex-start;
 }
 
   .filter-panel.open {


### PR DESCRIPTION
## Summary
- Replace menu dropdown text items with neutral `sl-button`s and style them for full-width alignment
- Use a neutral `sl-button` for series links instead of the text variant
- Style menu dropdown buttons for visibility and left alignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a42a423d24832dbaac5628eb568d42