### PR TITLE
Fix mobile search results artwork scaling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -124,6 +124,13 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   }
 
+  .movie-card img[slot="image"] {
+    display: block;
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+  }
+
     .actions {
       display: flex;
       flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Ensure result artwork images scale within their cards so the entire artwork is visible on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a42ce038f4832db57fe7cc8c45dce1