### PR TITLE
Fix manual auth submission

### DIFF
--- a/src/components/AuthPanel.jsx
+++ b/src/components/AuthPanel.jsx
@@ -91,7 +91,7 @@ export default function AuthPanel({ onSession, onClose }) {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />
-          <sl-button variant="primary" type="submit">
+          <sl-button variant="primary" type="submit" onClick={signUp}>
             Sign Up
           </sl-button>
         </form>
@@ -109,7 +109,7 @@ export default function AuthPanel({ onSession, onClose }) {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />
-          <sl-button variant="primary" type="submit">
+          <sl-button variant="primary" type="submit" onClick={signIn}>
             Sign In
           </sl-button>
         </form>


### PR DESCRIPTION
## Summary
- attach click handlers to email/password auth buttons so they trigger sign up or sign in actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4df838174832db30d85175f4c2594