### PR TITLE
Fix sign in and sign up buttons not responding

### DIFF
--- a/src/components/AuthPanel.jsx
+++ b/src/components/AuthPanel.jsx
@@ -8,7 +8,7 @@ export default function AuthPanel({ onSession, onClose }) {
   const [mode, setMode] = useState('sign_in');
 
   const signIn = async (e) => {
-    e.preventDefault();
+    e?.preventDefault();
     const { data, error } = await supabase.auth.signInWithPassword({
       email,
       password,
@@ -21,7 +21,7 @@ export default function AuthPanel({ onSession, onClose }) {
   };
 
   const signUp = async (e) => {
-    e.preventDefault();
+    e?.preventDefault();
     const { data, error } = await supabase.auth.signUp({
       email,
       password,


### PR DESCRIPTION
## Summary
- Prevent auth actions from throwing when no event object is supplied
- Ensure Sign In and Sign Up buttons trigger Supabase auth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a520326850832db0e631f2d4e29d50