### PR TITLE
Use Google ID token sign-in

### DIFF
--- a/src/components/AuthPanel.jsx
+++ b/src/components/AuthPanel.jsx
@@ -36,12 +36,16 @@ export default function AuthPanel({ onSession, onClose }) {
 
   const googleButtonRef = useRef(null);
 
-  const signInWithGoogle = async () => {
-    const { error } = await supabase.auth.signInWithOAuth({
+  const handleGoogleCallback = async (response) => {
+    const { data, error } = await supabase.auth.signInWithIdToken({
       provider: 'google',
-      options: { redirectTo: import.meta.env.VITE_SITE_URL },
+      token: response.credential,
     });
     if (error) toast(error.message, 'danger', 5000, 'exclamation-octagon');
+    else {
+      toast('Signed in successfully.', 'success', 5000, 'check-circle');
+      onSession?.(data.session);
+    }
   };
 
   useEffect(() => {
@@ -52,21 +56,16 @@ export default function AuthPanel({ onSession, onClose }) {
       if (window.google && googleButtonRef.current) {
         window.google.accounts.id.initialize({
           client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
-          callback: () => {},
+          callback: handleGoogleCallback,
         });
         window.google.accounts.id.renderButton(
           googleButtonRef.current,
           { theme: 'outline', size: 'large', text: 'signin_with' }
         );
-        const btn = googleButtonRef.current.querySelector('div[role="button"]');
-        btn?.addEventListener('click', signInWithGoogle);
       }
     };
     document.body.appendChild(script);
-    return () => {
-      const btn = googleButtonRef.current?.querySelector('div[role="button"]');
-      btn?.removeEventListener('click', signInWithGoogle);
-    };
+    return () => {};
   }, []);
 
   return (

--- a/src/components/AuthPanel.jsx
+++ b/src/components/AuthPanel.jsx
@@ -65,7 +65,16 @@ export default function AuthPanel({ onSession, onClose }) {
       }
     };
     document.body.appendChild(script);
-    return () => {};
+    return () => {
+      // Remove the Google SDK script
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+      // Remove the rendered Google button
+      if (googleButtonRef.current) {
+        googleButtonRef.current.innerHTML = '';
+      }
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- Replace OAuth redirect with signInWithIdToken in Google sign-in callback
- Initialize Google SDK with our callback and let it manage button interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a53dd60ec8832d861fcf569253a28d