### PR TITLE
Guard async state updates in panels

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -19,32 +19,40 @@ export default function FilterPanel({ filters = {}, onApply, onClose }) {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
+    let active = true;
     const fetchMeta = async () => {
       try {
         const [movieGenresRes, tvGenresRes] = await Promise.all([
           fetch(`https://api.themoviedb.org/3/genre/movie/list?api_key=${TMDB_API_KEY}`),
           fetch(`https://api.themoviedb.org/3/genre/tv/list?api_key=${TMDB_API_KEY}`),
         ]);
+        if (!active) return;
         const movieGenres = await movieGenresRes.json();
         const tvGenres = await tvGenresRes.json();
+        if (!active) return;
         const combined = [...(movieGenres.genres || []), ...(tvGenres.genres || [])];
         const names = Array.from(new Set(combined.map((g) => g.name)));
-        setGenreOptions(names);
+        if (active) setGenreOptions(names);
 
         const provRes = await fetch(
           `https://api.themoviedb.org/3/watch/providers/movie?api_key=${TMDB_API_KEY}&watch_region=US`
         );
+        if (!active) return;
         const provData = await provRes.json();
+        if (!active) return;
         const provNames = (provData.results || [])
           .map((p) => normalizeProviderName(p.provider_name))
           .filter((p) => US_STREAMING_PROVIDERS.includes(p));
-        setProviderOptions(Array.from(new Set(provNames)));
+        if (active) setProviderOptions(Array.from(new Set(provNames)));
       } catch (_) {
         // ignore
       }
     };
     fetchMeta();
     setOpen(true);
+    return () => {
+      active = false;
+    };
   }, []);
 
   const handleGenres = (e) => {

--- a/src/components/SeenList.jsx
+++ b/src/components/SeenList.jsx
@@ -32,7 +32,6 @@ export default function SeenList({ session, onClose }) {
   };
 
   useEffect(() => {
-    activeRef.current = true;
     fetchItems();
     setOpen(true);
     return () => {

--- a/src/components/SeenList.jsx
+++ b/src/components/SeenList.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { supabase } from '../lib/supabaseClient.js';
 import Search from './Search.jsx';
 import { toast } from '../lib/toast.js';
@@ -7,6 +7,7 @@ export default function SeenList({ session, onClose }) {
   const [seenItems, setSeenItems] = useState([]);
   const [pinnedItems, setPinnedItems] = useState([]);
   const [open, setOpen] = useState(false);
+  const activeRef = useRef(true);
 
   const fetchItems = async () => {
     if (session) {
@@ -16,6 +17,7 @@ export default function SeenList({ session, onClose }) {
         .eq('user_id', session.user.id)
         .eq('list', 'seen')
         .order('id');
+      if (!activeRef.current) return;
       if (error) {
         toast(error.message, 'danger', 5000, 'exclamation-octagon');
       } else if (data) {
@@ -23,15 +25,19 @@ export default function SeenList({ session, onClose }) {
       }
     } else {
       const seen = JSON.parse(sessionStorage.getItem('seen') || '[]');
-      setSeenItems(seen);
+      if (activeRef.current) setSeenItems(seen);
     }
     const pinned = JSON.parse(sessionStorage.getItem('pinned') || '[]');
-    setPinnedItems(pinned);
+    if (activeRef.current) setPinnedItems(pinned);
   };
 
   useEffect(() => {
+    activeRef.current = true;
     fetchItems();
     setOpen(true);
+    return () => {
+      activeRef.current = false;
+    };
   }, [session]);
 
   const addItem = async (item) => {


### PR DESCRIPTION
## Summary
- prevent FilterPanel from updating state after unmount by tracking an `active` flag and cleaning up on unmount
- ensure SeenList's initial fetch and subsequent updates only set state while mounted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a54078d634832d8f2c8ed07cb13363