### PR TITLE
fix card layout overflow

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -153,10 +153,10 @@ body {
   }
 
   .movie-card {
-    height: 720px;
     display: flex;
     flex-direction: column;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
+    height: 100%;
   }
 
   .movie-card:hover {
@@ -168,13 +168,13 @@ body {
     border: 1px solid var(--color-border);
     border-radius: 16px;
     overflow: hidden;
-    box-shadow: 
+    box-shadow:
       0 4px 6px -1px rgba(0, 0, 0, 0.1),
       0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    height: 720px;
     display: flex;
     flex-direction: column;
     transition: all 0.3s ease;
+    height: 100%;
   }
 
   .movie-card:hover::part(base) {
@@ -203,8 +203,6 @@ body {
     gap: 0.75rem;
     background: var(--gradient-card);
     text-align: center;
-    height: 220px;
-    overflow: hidden;
   }
 
   .movie-card .title-box {
@@ -333,7 +331,6 @@ body {
     padding-top: 1rem;
     background: var(--gradient-card);
     border-top: 1px solid var(--color-border);
-    height: 80px;
     display: flex;
     align-items: center;
   }
@@ -344,14 +341,12 @@ body {
     display: flex;
     flex-direction: column;
     padding: 0;
-    height: 220px;
   }
 
   .movie-card::part(footer) {
     flex-shrink: 0;
     padding: 0;
     margin-top: auto;
-    height: 80px;
     display: flex;
     align-items: center;
   }
@@ -359,7 +354,6 @@ body {
   /* Ensure all cards in the grid have the same height */
   .results-list li {
     display: flex;
-    height: 720px;
   }
 
   .actions {
@@ -455,14 +449,6 @@ body {
       gap: 1.25rem;
     }
 
-    .movie-card {
-      height: 680px;
-    }
-
-    .movie-card::part(base) {
-      height: 680px;
-    }
-
     .movie-card img[slot="image"] {
       height: 380px;
     }
@@ -470,25 +456,11 @@ body {
     .movie-card .card-body {
       padding: 1.25rem;
       gap: 0.75rem;
-      height: 220px;
     }
 
     .movie-card [slot="footer"] {
       padding: 1.25rem;
       padding-top: 1rem;
-      height: 80px;
-    }
-
-    .movie-card::part(body) {
-      height: 220px;
-    }
-
-    .movie-card::part(footer) {
-      height: 80px;
-    }
-
-    .results-list li {
-      height: 680px;
     }
 
     .actions {
@@ -514,14 +486,6 @@ body {
       margin: 1rem 0;
     }
 
-    .movie-card {
-      height: 640px;
-    }
-
-    .movie-card::part(base) {
-      height: 640px;
-    }
-
     .movie-card img[slot="image"] {
       height: 350px;
       object-position: center center;
@@ -530,30 +494,15 @@ body {
     .movie-card .card-body {
       padding: 1rem;
       gap: 0.75rem;
-      height: 210px;
     }
 
     .movie-card .title-box {
       font-size: 1.05rem;
-      height: 2.6rem;
     }
 
     .movie-card [slot="footer"] {
       padding: 1rem;
       padding-top: 1rem;
-      height: 80px;
-    }
-
-    .movie-card::part(body) {
-      height: 210px;
-    }
-
-    .movie-card::part(footer) {
-      height: 80px;
-    }
-
-    .results-list li {
-      height: 640px;
     }
 
     .actions {


### PR DESCRIPTION
## Summary
- remove fixed-height constraints from movie cards so buttons and tags are no longer clipped
- allow card body and footer to expand naturally for consistent card sizes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5761e5128832dba36d11849a99f7c