### PR TITLE
Ensure consistent movie card layout

### DIFF
--- a/src/components/ResultsList.jsx
+++ b/src/components/ResultsList.jsx
@@ -68,13 +68,17 @@ export default function ResultsList({
                     <span className="tag tag--runtime">Length: {r.runtime}m</span>
                   )}
                 </div>
-                {r.streaming && (
+                {r.streaming ? (
                   <div className="streaming">
                     {r.streaming.map((s) => (
                       <span key={s} className={`badge service-${slugify(s)}`}>
                         {s}
                       </span>
                     ))}
+                  </div>
+                ) : (
+                  <div className="streaming" style={{ visibility: 'hidden' }}>
+                    <span className="badge">placeholder</span>
                   </div>
                 )}
                 {r.genres && (
@@ -87,18 +91,26 @@ export default function ResultsList({
                   </div>
                 )}
                 <div className="ratings">
-                  {r.ratings.tmdb != null && (
+                  {r.ratings.tmdb != null ? (
                     <span className="badge rating rating--tmdb">
                       TMDB: {r.ratings.tmdb.toFixed ? r.ratings.tmdb.toFixed(1) : r.ratings.tmdb}
                     </span>
+                  ) : (
+                    <div className="badge rating rating--tmdb" style={{ visibility: 'hidden' }}>
+                      TMDB
+                    </div>
                   )}
-                  {r.ratings.rottenTomatoes != null && (
+                  {r.ratings.rottenTomatoes != null ? (
                     <span className="badge rating rating--rotten">
                       RT: {r.ratings.rottenTomatoes}%
                     </span>
+                  ) : (
+                    <div className="badge rating rating--rotten" style={{ visibility: 'hidden' }}>
+                      RT
+                    </div>
                   )}
                 </div>
-                {r.series && (
+                {r.series ? (
                   <sl-button
                     variant="neutral"
                     type="button"
@@ -107,6 +119,10 @@ export default function ResultsList({
                   >
                     Series
                   </sl-button>
+                ) : (
+                  <div style={{ visibility: 'hidden' }}>
+                    <sl-button variant="neutral" type="button">Series</sl-button>
+                  </div>
                 )}
               </div>
               <div slot="footer" className="actions">

--- a/src/styles.css
+++ b/src/styles.css
@@ -150,11 +150,13 @@ body {
     gap: 1.5rem;
     grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
     align-items: stretch;
+    grid-auto-rows: 1fr;
   }
 
   .movie-card {
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     height: 100%;
   }
@@ -173,6 +175,7 @@ body {
       0 2px 4px -1px rgba(0, 0, 0, 0.06);
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     transition: all 0.3s ease;
     height: 100%;
   }
@@ -187,8 +190,8 @@ body {
   .movie-card img[slot="image"] {
     display: block;
     width: 100%;
-    height: 420px;
-    object-fit: contain;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
     object-position: center;
     flex-shrink: 0;
     background: var(--color-surface-elevated);
@@ -199,6 +202,7 @@ body {
     flex: 1;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     padding: 1.5rem;
     gap: 0.75rem;
     background: var(--gradient-card);
@@ -447,10 +451,11 @@ body {
     .results-list {
       grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
       gap: 1.25rem;
+      grid-auto-rows: 1fr;
     }
 
     .movie-card img[slot="image"] {
-      height: 380px;
+      aspect-ratio: 2 / 3;
     }
 
     .movie-card .card-body {
@@ -484,10 +489,11 @@ body {
       grid-template-columns: 1fr;
       gap: 1rem;
       margin: 1rem 0;
+      grid-auto-rows: 1fr;
     }
 
     .movie-card img[slot="image"] {
-      height: 350px;
+      aspect-ratio: 2 / 3;
       object-position: center center;
     }
 
@@ -624,6 +630,7 @@ body {
 
     .results-list {
       grid-template-columns: 1fr;
+      grid-auto-rows: 1fr;
     }
 
     .actions {


### PR DESCRIPTION
## Summary
- Use flexbox and grid settings to enforce equal card heights and align footers
- Maintain 2:3 poster aspect ratio and cover-fit images
- Add hidden placeholders for optional streaming, rating, and series elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a57bcb67a0832da2713838ea8d3fb7