### PR TITLE
Enable sliding series panel and sort entries by release date

### DIFF
--- a/src/components/SeriesPanel.jsx
+++ b/src/components/SeriesPanel.jsx
@@ -3,6 +3,7 @@ import { fetchSeriesEntries } from '../lib/series.js';
 
 export default function SeriesPanel({ series, onClose }) {
   const [entries, setEntries] = useState([]);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -15,13 +16,14 @@ export default function SeriesPanel({ series, onClose }) {
       }
     };
     load();
+    setOpen(true);
     return () => {
       active = false;
     };
   }, [series]);
 
   return (
-    <div className="panel side-panel">
+    <div className={`panel side-panel ${open ? 'open' : ''}`}>
       <div className="row row--actions">
         <h2>{series?.name || 'Series'}</h2>
         <sl-button variant="neutral" type="button" onClick={onClose}>

--- a/src/lib/series.js
+++ b/src/lib/series.js
@@ -33,14 +33,20 @@ export async function fetchSeriesEntries(series) {
       const data = await res.json();
       if (data?.Episodes) {
         for (const ep of data.Episodes) {
+          const released = ep.Released && ep.Released !== 'N/A' ? ep.Released : null;
           results.push({
             imdbID: ep.imdbID,
             title: `S${season}E${ep.Episode} - ${ep.Title}`,
+            releaseDate: released,
           });
         }
       }
     }
-    return results;
+    return results.sort((a, b) => {
+      const da = a.releaseDate ? new Date(a.releaseDate) : 0;
+      const db = b.releaseDate ? new Date(b.releaseDate) : 0;
+      return da - db;
+    });
   }
   return [];
 }

--- a/src/lib/series.test.js
+++ b/src/lib/series.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('fetchSeriesEntries', () => {
+  it('sorts TMDB collection entries by release date', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_TMDB_API_KEY', 'tmdb-key');
+    const { fetchSeriesEntries } = await import('./series');
+
+    const mockResponse = {
+      parts: [
+        { id: 1, title: 'B', release_date: '2020-01-01' },
+        { id: 2, title: 'A', release_date: '2019-01-01' }
+      ]
+    };
+    const fetchMock = vi.fn(() => Promise.resolve({ json: () => Promise.resolve(mockResponse) }));
+    global.fetch = fetchMock;
+
+    const result = await fetchSeriesEntries({ type: 'tmdb', id: 123 });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result).toEqual([
+      { id: 2, title: 'A', releaseDate: '2019-01-01' },
+      { id: 1, title: 'B', releaseDate: '2020-01-01' }
+    ]);
+  });
+
+  it('sorts OMDb episodes by release date', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_OMDB_PROXY_URL', 'https://example.com/omdb');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'sb-anon');
+    const { fetchSeriesEntries } = await import('./series');
+
+    const season1 = {
+      Episodes: [
+        { Episode: '1', Title: 'Ep1', imdbID: 'e1', Released: '02 Jan 2020' },
+        { Episode: '2', Title: 'Ep2', imdbID: 'e2', Released: '01 Jan 2020' }
+      ]
+    };
+
+    const fetchMock = vi.fn(() => Promise.resolve({ json: () => Promise.resolve(season1) }));
+    global.fetch = fetchMock;
+
+    const result = await fetchSeriesEntries({ type: 'omdb', imdbId: 'tt123', totalSeasons: '1' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('https://example.com/omdb?i=tt123&Season=1'),
+      expect.anything()
+    );
+    expect(result).toEqual([
+      { imdbID: 'e2', title: 'S1E2 - Ep2', releaseDate: '01 Jan 2020' },
+      { imdbID: 'e1', title: 'S1E1 - Ep1', releaseDate: '02 Jan 2020' }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure series pop-out panel slides in by tracking an `open` state
- Include release dates when fetching series entries from OMDb and sort them chronologically
- Add unit tests for TMDB and OMDb series entry sorting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a615d36df4832d818a3df48bcf8f8d