### PR TITLE
fix: improve mobile actions sizing

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -524,8 +524,8 @@ body {
     .actions sl-button::part(base) {
       width: 100%;
       justify-content: center;
-      padding: 0.875rem 1rem;
-      font-size: 0.875rem;
+      padding: 0.75rem 0.875rem;
+      font-size: 0.8rem;
       font-weight: 600;
       border-radius: 12px;
       min-width: 0;
@@ -650,10 +650,18 @@ body {
     .actions {
       width: 100%;
       flex-direction: column;
+      gap: 0.5rem;
     }
 
     .actions sl-button {
       width: 100%;
+    }
+
+    .actions sl-button::part(base) {
+      width: 100%;
+      min-width: 0;
+      padding: 0.75rem 0.875rem;
+      font-size: 0.8rem;
     }
   }
 


### PR DESCRIPTION
## Summary
- shrink action buttons on small screens
- ensure buttons stay within card footer on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a62fa542b8832d8665a5839f42ab38