### PR TITLE
feat: add metadata loading state to filters

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -20,11 +20,13 @@ export default function FilterPanel({ filters = {}, onApply, onClose }) {
   const [minTmdb, setMinTmdb] = useState(Number(filters.minTmdb) || 0);
   const [minRotten, setMinRotten] = useState(Number(filters.minRotten) || 0);
   const [open, setOpen] = useState(false);
+  const [loadingMeta, setLoadingMeta] = useState(true);
 
   useEffect(() => {
     let active = true;
     const fetchMeta = async () => {
       try {
+        if (active) setLoadingMeta(true);
         const [movieGenresRes, tvGenresRes] = await Promise.all([
           fetch(`https://api.themoviedb.org/3/genre/movie/list?api_key=${TMDB_API_KEY}`),
           fetch(`https://api.themoviedb.org/3/genre/tv/list?api_key=${TMDB_API_KEY}`),
@@ -49,6 +51,8 @@ export default function FilterPanel({ filters = {}, onApply, onClose }) {
         if (active) setProviderOptions(Array.from(new Set(provNames)));
       } catch (_) {
         // ignore
+      } finally {
+        if (active) setLoadingMeta(false);
       }
     };
     fetchMeta();
@@ -118,22 +122,30 @@ export default function FilterPanel({ filters = {}, onApply, onClose }) {
               ))}
             </div>
             <div className="options">
-              {genreOptions
-                .filter((g) => g.toLowerCase().includes(genreSearch.toLowerCase()))
-                .map((g) => (
-                  <label key={g}>
-                    <input
-                      type="checkbox"
-                      checked={selectedGenres.includes(g)}
-                      onChange={(e) =>
-                        e.target.checked
-                          ? setSelectedGenres(prev => [...prev, g])
-                          : removeGenre(g)
-                      }
-                    />
-                    {g}
-                  </label>
-                ))}
+              {loadingMeta ? (
+                <div className="loading-spinner">
+                  <sl-spinner></sl-spinner>
+                </div>
+              ) : (
+                genreOptions
+                  .filter((g) =>
+                    g.toLowerCase().includes(genreSearch.toLowerCase())
+                  )
+                  .map((g) => (
+                    <label key={g}>
+                      <input
+                        type="checkbox"
+                        checked={selectedGenres.includes(g)}
+                        onChange={(e) =>
+                          e.target.checked
+                            ? setSelectedGenres(prev => [...prev, g])
+                            : removeGenre(g)
+                        }
+                      />
+                      {g}
+                    </label>
+                  ))
+              )}
             </div>
           </div>
         </label>
@@ -171,22 +183,30 @@ export default function FilterPanel({ filters = {}, onApply, onClose }) {
               ))}
             </div>
             <div className="options">
-              {providerOptions
-                .filter((p) => p.toLowerCase().includes(providerSearch.toLowerCase()))
-                .map((p) => (
-                  <label key={p}>
-                    <input
-                      type="checkbox"
-                      checked={providers.includes(p)}
-                      onChange={(e) =>
-                        e.target.checked
-                          ? setProviders(prev => [...prev, p])
-                          : removeProvider(p)
-                      }
-                    />
-                    {p}
-                  </label>
-                ))}
+              {loadingMeta ? (
+                <div className="loading-spinner">
+                  <sl-spinner></sl-spinner>
+                </div>
+              ) : (
+                providerOptions
+                  .filter((p) =>
+                    p.toLowerCase().includes(providerSearch.toLowerCase())
+                  )
+                  .map((p) => (
+                    <label key={p}>
+                      <input
+                        type="checkbox"
+                        checked={providers.includes(p)}
+                        onChange={(e) =>
+                          e.target.checked
+                            ? setProviders(prev => [...prev, p])
+                            : removeProvider(p)
+                        }
+                      />
+                      {p}
+                    </label>
+                  ))
+              )}
             </div>
           </div>
         </label>
@@ -233,7 +253,12 @@ export default function FilterPanel({ filters = {}, onApply, onClose }) {
           </div>
         </label>
       </div>
-      <sl-button variant="primary" type="button" onClick={apply}>
+      <sl-button
+        variant="primary"
+        type="button"
+        disabled={loadingMeta}
+        onClick={apply}
+      >
         Search
       </sl-button>
     </aside>


### PR DESCRIPTION
## Summary
- track metadata fetching state in FilterPanel
- show spinner placeholders for genres and providers until loaded
- disable Search button until metadata is ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a648236f60832d88390ed0cc644591