### PR TITLE
Add reset button to filter panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -132,6 +132,27 @@ function App() {
     }
   };
 
+  const resetFilters = async () => {
+    const defaults = {
+      mediaType: 'movie',
+      genres: [],
+      releaseDate: 'any',
+      providers: [],
+      seriesOnly: false,
+      minTmdb: 0,
+      minRotten: 0,
+      isGeneralSearch: true,
+    };
+    setFilters(defaults);
+    setShowFilters(false);
+    startLoading();
+    try {
+      await loadResults(defaults);
+    } finally {
+      stopLoading();
+    }
+  };
+
   const rollAgain = async () => {
     startLoading();
     try {
@@ -193,6 +214,7 @@ function App() {
           filters={filters}
           onApply={applyFilters}
           onClose={() => setShowFilters(false)}
+          onReset={resetFilters}
         />
       )}
       {loading && (

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -7,7 +7,7 @@ import config from '../lib/config.js';
 
 const TMDB_API_KEY = config.tmdbApiKey;
 
-export default function FilterPanel({ filters = {}, onApply, onClose }) {
+export default function FilterPanel({ filters = {}, onApply, onClose, onReset }) {
   const [mediaType, setMediaType] = useState(filters.mediaType || 'movie');
   const [genreOptions, setGenreOptions] = useState([]);
   const [selectedGenres, setSelectedGenres] = useState(filters.genres || []);
@@ -78,8 +78,37 @@ export default function FilterPanel({ filters = {}, onApply, onClose }) {
       seriesOnly,
       minTmdb,
       minRotten,
-      isGeneralSearch: selectedGenres.length === 0 && providers.length === 0 && releaseDate === 'any' && !seriesOnly && minTmdb === 0 && minRotten === 0,
+      isGeneralSearch:
+        selectedGenres.length === 0 &&
+        providers.length === 0 &&
+        releaseDate === 'any' &&
+        !seriesOnly &&
+        minTmdb === 0 &&
+        minRotten === 0,
     });
+  };
+
+  const reset = () => {
+    const defaults = {
+      mediaType: 'movie',
+      genres: [],
+      releaseDate: 'any',
+      providers: [],
+      seriesOnly: false,
+      minTmdb: 0,
+      minRotten: 0,
+      isGeneralSearch: true,
+    };
+    setMediaType(defaults.mediaType);
+    setSelectedGenres(defaults.genres);
+    setGenreSearch('');
+    setReleaseDate(defaults.releaseDate);
+    setProviders(defaults.providers);
+    setProviderSearch('');
+    setSeriesOnly(defaults.seriesOnly);
+    setMinTmdb(defaults.minTmdb);
+    setMinRotten(defaults.minRotten);
+    onReset?.(defaults);
   };
 
   // Always allow search - no longer disable based on loading or selections
@@ -258,14 +287,19 @@ export default function FilterPanel({ filters = {}, onApply, onClose }) {
           </div>
         </label>
       </div>
-      <sl-button
-        variant="primary"
-        type="button"
-        disabled={disableSearch}
-        onClick={apply}
-      >
-        {isGeneralSearch ? 'Discover Random Content' : 'Search with Filters'}
-      </sl-button>
+      <div className="row row--actions">
+        <sl-button variant="neutral" type="button" onClick={reset}>
+          Reset Filters
+        </sl-button>
+        <sl-button
+          variant="primary"
+          type="button"
+          disabled={disableSearch}
+          onClick={apply}
+        >
+          {isGeneralSearch ? 'Discover Random Content' : 'Search with Filters'}
+        </sl-button>
+      </div>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- add Reset Filters button to filter panel
- allow parent components to react via new `onReset` prop
- style reset control neutral and wire app to reload default results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65d0d221c832da48149317f1e1cbc