### PR TITLE
Sort filter options alphabetically

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -35,7 +35,9 @@ export default function FilterPanel({ filters = {}, onApply, onClose, onReset })
         const tvGenres = await tvGenresRes.json();
         if (!active) return;
         const combined = [...(movieGenres.genres || []), ...(tvGenres.genres || [])];
-        const names = Array.from(new Set(combined.map((g) => g.name)));
+        const names = Array.from(new Set(combined.map((g) => g.name))).sort((a, b) =>
+          a.localeCompare(b)
+        );
         if (active) setGenreOptions(names);
 
         const provRes = await fetch(
@@ -44,10 +46,14 @@ export default function FilterPanel({ filters = {}, onApply, onClose, onReset })
         if (!active) return;
         const provData = await provRes.json();
         if (!active) return;
-        const provNames = (provData.results || [])
-          .map((p) => normalizeProviderName(p.provider_name))
-          .filter((p) => US_STREAMING_PROVIDERS.includes(p));
-        if (active) setProviderOptions(Array.from(new Set(provNames)));
+        const provNames = Array.from(
+          new Set(
+            (provData.results || [])
+              .map((p) => normalizeProviderName(p.provider_name))
+              .filter((p) => US_STREAMING_PROVIDERS.includes(p))
+          )
+        ).sort((a, b) => a.localeCompare(b));
+        if (active) setProviderOptions(provNames);
       } catch (_) {
         // ignore
       } finally {


### PR DESCRIPTION
## Summary
- sort genre options alphabetically before setting state
- sort provider options alphabetically before setting state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a668f53284832d802256949e65307f