### PR TITLE
Fix non-clickable search button in filter panel

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   normalizeProviderName,
   US_STREAMING_PROVIDERS,
@@ -116,9 +116,6 @@ export default function FilterPanel({ filters = {}, onApply, onClose, onReset })
     setMinRotten(defaults.minRotten);
     onReset?.(defaults);
   };
-
-  // Always allow search - no longer disable based on loading or selections
-  const disableSearch = false;
 
   const isGeneralSearch = selectedGenres.length === 0 && providers.length === 0 && releaseDate === 'any' && !seriesOnly && minTmdb === 0 && minRotten === 0;
 
@@ -300,7 +297,6 @@ export default function FilterPanel({ filters = {}, onApply, onClose, onReset })
         <sl-button
           variant="primary"
           type="button"
-          disabled={disableSearch}
           onClick={apply}
         >
           {isGeneralSearch ? 'Discover Random Content' : 'Search with Filters'}

--- a/src/components/FilterPanel.test.jsx
+++ b/src/components/FilterPanel.test.jsx
@@ -1,0 +1,42 @@
+import React, { act } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import FilterPanel from './FilterPanel.jsx';
+
+// Ensure Shoelace custom elements do not interfere with tests
+// by defining a minimal stub for sl-button
+class SlButton extends HTMLElement {}
+customElements.define('sl-button', SlButton);
+
+// Same for sl-tag and sl-spinner maybe? Wait FilterPanel uses sl-tag and sl-spinner.
+// Since our test renders FilterPanel but not interact with sl-tag or sl-spinner, we may need to define them to prevent errors? In jsdom, unknown elements are fine; but to avoid warnings, we may define simple stubs for 'sl-tag' and 'sl-spinner'. However we don't need them if they are not observed? Actually, React will call customElements.get to check? For not defined custom elements, we may just leave; but to be safe, define them.
+class SlTag extends HTMLElement {}
+customElements.define('sl-tag', SlTag);
+class SlSpinner extends HTMLElement {}
+customElements.define('sl-spinner', SlSpinner);
+
+
+describe('FilterPanel search button', () => {
+  it('is enabled and triggers onApply when clicked', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const onApply = vi.fn();
+
+    let root;
+    act(() => {
+      root = createRoot(container);
+      root.render(<FilterPanel onApply={onApply} />);
+    });
+
+    const button = container.querySelector('sl-button[variant="primary"]');
+    expect(button).toBeTruthy();
+    // Button should not be disabled
+    expect(button.hasAttribute('disabled')).toBe(false);
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onApply).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- remove disabled state from filter search button and ensure React import for compatibility
- add test verifying search button is enabled and triggers onApply

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a67202726c832d96dc1e530c2ee84e