### PR TITLE
Fix discover pagination and add no-results feedback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -286,6 +286,11 @@ function App() {
           onShowSeries={(s) => setSeries(s)}
         />
       )}
+      {!loading && results.length === 0 && (
+        <div className="panel">
+          <p>No results found. Try adjusting your filters.</p>
+        </div>
+      )}
       {series && <SeriesPanel series={series} onClose={() => setSeries(null)} />}
       {showSeen && (
         <SeenList

--- a/src/lib/api.test.js
+++ b/src/lib/api.test.js
@@ -128,7 +128,12 @@ describe('discoverTitles', () => {
         json: () =>
           Promise.resolve({ results: [{ provider_name: 'Netflix', provider_id: 8 }] })
       })
-      // discover results
+      // discover first page (to get total_pages)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_pages: 500, results: [] })
+      })
+      // discover random page results
       .mockResolvedValueOnce({
         ok: true,
         json: () =>
@@ -144,7 +149,7 @@ describe('discoverTitles', () => {
       minTmdb: 7
     });
 
-    const url = fetchMock.mock.calls[2][0];
+    const url = fetchMock.mock.calls[3][0];
     expect(url).toContain('/discover/movie?');
     expect(url).toContain('with_genres=28');
     expect(url).toContain('with_watch_providers=8');


### PR DESCRIPTION
## Summary
- handle TMDB discover pagination correctly and randomize pages within range
- randomize trending pages with fallback to avoid repeated results
- display a helpful message when filter searches return no results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6750f1bd4832db170982e98f269ff