### PR TITLE
Ensure streaming-only defaults and restore Rotten Tomatoes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ function App() {
     seriesOnly: false,
     minTmdb: '',
     minRotten: '',
+    notStreaming: false,
     isGeneralSearch: true,
   });
   const [results, setResults] = useState([]);
@@ -78,7 +79,8 @@ function App() {
           !f.providers?.length &&
           !f.seriesOnly &&
           !f.minTmdb &&
-          !f.minRotten);
+          !f.minRotten &&
+          !f.notStreaming);
 
     let data;
     let resultsTitle = 'Trending';
@@ -131,7 +133,12 @@ function App() {
         if (f.releaseDate === 'past_year' && diff > 1) return false;
         if (f.releaseDate === 'older' && diff <= 1) return false;
       }
-      if (f.providers.length && !f.providers.some((p) => r.streaming?.includes(p))) return false;
+      if (!f.notStreaming && f.providers.length && !f.providers.some((p) => r.streaming?.includes(p))) return false;
+      if (f.notStreaming) {
+        if (r.streaming?.length) return false;
+      } else {
+        if (!r.streaming?.length) return false;
+      }
       if (f.seriesOnly && !r.series) return false;
       if (f.minTmdb && (r.ratings.tmdb ?? 0) < parseFloat(f.minTmdb)) return false;
       if (
@@ -177,6 +184,7 @@ function App() {
       seriesOnly: false,
       minTmdb: 0,
       minRotten: 0,
+      notStreaming: false,
       isGeneralSearch: true,
     };
     setFilters(defaults);

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -19,6 +19,7 @@ export default function FilterPanel({ filters = {}, onApply, onClose, onReset })
   const [seriesOnly, setSeriesOnly] = useState(filters.seriesOnly || false);
   const [minTmdb, setMinTmdb] = useState(Number(filters.minTmdb) || 0);
   const [minRotten, setMinRotten] = useState(Number(filters.minRotten) || 0);
+  const [notStreaming, setNotStreaming] = useState(filters.notStreaming || false);
   const [open, setOpen] = useState(false);
   const [loadingMeta, setLoadingMeta] = useState(true);
 
@@ -84,13 +85,15 @@ export default function FilterPanel({ filters = {}, onApply, onClose, onReset })
       seriesOnly,
       minTmdb,
       minRotten,
+      notStreaming,
       isGeneralSearch:
         selectedGenres.length === 0 &&
         providers.length === 0 &&
         releaseDate === 'any' &&
         !seriesOnly &&
         minTmdb === 0 &&
-        minRotten === 0,
+        minRotten === 0 &&
+        !notStreaming,
     });
   };
 
@@ -103,6 +106,7 @@ export default function FilterPanel({ filters = {}, onApply, onClose, onReset })
       seriesOnly: false,
       minTmdb: 0,
       minRotten: 0,
+      notStreaming: false,
       isGeneralSearch: true,
     };
     setMediaType(defaults.mediaType);
@@ -114,10 +118,11 @@ export default function FilterPanel({ filters = {}, onApply, onClose, onReset })
     setSeriesOnly(defaults.seriesOnly);
     setMinTmdb(defaults.minTmdb);
     setMinRotten(defaults.minRotten);
+    setNotStreaming(defaults.notStreaming);
     onReset?.(defaults);
   };
 
-  const isGeneralSearch = selectedGenres.length === 0 && providers.length === 0 && releaseDate === 'any' && !seriesOnly && minTmdb === 0 && minRotten === 0;
+  const isGeneralSearch = selectedGenres.length === 0 && providers.length === 0 && releaseDate === 'any' && !seriesOnly && minTmdb === 0 && minRotten === 0 && !notStreaming;
 
   return (
     <aside className={`filter-panel ${open ? 'open' : ''}`}>
@@ -246,6 +251,16 @@ export default function FilterPanel({ filters = {}, onApply, onClose, onReset })
               )}
             </div>
           </div>
+        </label>
+      </div>
+      <div className="filter-group">
+        <label>
+          <input
+            type="checkbox"
+            checked={notStreaming}
+            onChange={(e) => setNotStreaming(e.target.checked)}
+          />
+          {' '}Not currently streaming
         </label>
       </div>
       <div className="filter-group">

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -133,7 +133,7 @@ export async function fetchDetails(tmdbId) {
   if (imdbId) {
     if (OMDB_PROXY) {
       // proxy must include the apikey server-side; we call the proxy via HTTPS
-      const url = `${OMDB_PROXY.replace(/\/$/, '')}?i=${encodeURIComponent(imdbId)}`;
+      const url = `${OMDB_PROXY.replace(/\/$/, '')}?i=${encodeURIComponent(imdbId)}&tomatoes=true`;
       const headers = {};
       if (SB_ANON) {
         headers.apikey = SB_ANON;

--- a/src/lib/api.test.js
+++ b/src/lib/api.test.js
@@ -90,7 +90,7 @@ describe('fetchDetails', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(1, expect.stringContaining('/movie/1'));
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining('https://example.com/omdb-proxy?i=tt123'),
+      expect.stringContaining('https://example.com/omdb-proxy?i=tt123&tomatoes=true'),
       expect.anything()
     );
 

--- a/test-omdb.js
+++ b/test-omdb.js
@@ -16,7 +16,7 @@ async function testOMDBProxy() {
   console.log(`   Proxy URL: ${proxyUrl}`);
   
   try {
-    const url = `${proxyUrl}?i=${encodeURIComponent(testImdbId)}`;
+    const url = `${proxyUrl}?i=${encodeURIComponent(testImdbId)}&tomatoes=true`;
     const headers = {
       'apikey': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml1eWh2bWFyamZneHlrcGV1ZnNtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyOTg0MzAsImV4cCI6MjA3MDg3NDQzMH0.g_GqtGOW6ZGtnBjn_LuA6nKnSzQLYXxS6QamQBwe7oQ',
       'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml1eWh2bWFyamZneHlrcGV1ZnNtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyOTg0MzAsImV4cCI6MjA3MDg3NDQzMH0.g_GqtGOW6ZGtnBjn_LuA6nKnSzQLYXxS6QamQBwe7oQ'


### PR DESCRIPTION
## Summary
- restore Rotten Tomatoes scores by requesting tomatoes data from OMDb proxy
- only show titles on streaming services by default and add a "Not currently streaming" filter option
- include availability filter in results logic and developer OMDb test script

## Testing
- `npm test`
- `node test-omdb.js` *(fails: fetch failed – proxy env vars not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a678bcc9f4832daf222c8e3697e410