### PR TITLE
Add RT proxy URL to example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,6 @@ VITE_SUPABASE_URL=https://iuyhvmarjfgxykpeufsm.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml1eWh2bWFyamZneHlrcGV1ZnNtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyOTg0MzAsImV4cCI6MjA3MDg3NDQzMH0.g_GqtGOW6ZGtnBjn_LuA6nKnSzQLYXxS6QamQBwe7oQ
 VITE_SITE_URL=https://politivol.github.io/streampal/
 VITE_OMDB_PROXY_URL=https://iuyhvmarjfgxykpeufsm.supabase.co/functions/v1/omdb-proxy
+VITE_RT_PROXY_URL=https://iuyhvmarjfgxykpeufsm.supabase.co/functions/v1/rt-proxy
 VITE_GOOGLE_CLIENT_ID=263667459818-95ispqhvclmd4i1g9m6ousqbnprlp4d6.apps.googleusercontent.com
 VITE_TMDB_API_KEY=your-tmdb-api-key-here


### PR DESCRIPTION
## Summary
- document Rotten Tomatoes proxy edge function URL in example environment file

## Testing
- `npm test` *(fails: Missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68a69ee8ba50832d80948027f5af69f6